### PR TITLE
test: notify start up waiter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub async fn start_up(
     config: &'static Config,
     number_of_cache_actors: usize,
     endec: impl TEnDecoder,
+    start_flag: impl TNotifyStartUpWatier,
 ) -> Result<()> {
     let (cache_dispatcher, ttl_inbox) =
         CacheManager::run_cache_actors(number_of_cache_actors, endec);
@@ -28,6 +29,7 @@ pub async fn start_up(
         .await?;
 
     let listener = TcpListener::bind(config.bind_addr()).await?;
+    start_flag.notify_startup_waiter();
     loop {
         match listener.accept().await {
             Ok((socket, _)) =>
@@ -58,4 +60,11 @@ fn process_socket<T: TEnDecoder>(
             }
         }
     });
+}
+
+pub trait TNotifyStartUpWatier {
+    fn notify_startup_waiter(&self);
+}
+impl TNotifyStartUpWatier for () {
+    fn notify_startup_waiter(&self) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub async fn start_up(
     config: &'static Config,
     number_of_cache_actors: usize,
     endec: impl TEnDecoder,
-    start_flag: impl TNotifyStartUpWatier,
+    startup_notifier: impl TNotifyStartUp,
 ) -> Result<()> {
     let (cache_dispatcher, ttl_inbox) =
         CacheManager::run_cache_actors(number_of_cache_actors, endec);
@@ -29,7 +29,7 @@ pub async fn start_up(
         .await?;
 
     let listener = TcpListener::bind(config.bind_addr()).await?;
-    start_flag.notify_startup_waiter();
+    startup_notifier.notify_startup();
     loop {
         match listener.accept().await {
             Ok((socket, _)) =>
@@ -62,9 +62,9 @@ fn process_socket<T: TEnDecoder>(
     });
 }
 
-pub trait TNotifyStartUpWatier {
-    fn notify_startup_waiter(&self);
+pub trait TNotifyStartUp {
+    fn notify_startup(&self);
 }
-impl TNotifyStartUpWatier for () {
-    fn notify_startup_waiter(&self) {}
+impl TNotifyStartUp for () {
+    fn notify_startup(&self) {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ const NUM_OF_PERSISTENCE: usize = 10;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    start_up(config(), NUM_OF_PERSISTENCE, EnDecoder).await
+    start_up(config(), NUM_OF_PERSISTENCE, EnDecoder, ()).await
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use redis_starter_rust::{config::Config, TNotifyStartUpWatier};
+use redis_starter_rust::{config::Config, TNotifyStartUp};
 use std::sync::{Arc, OnceLock};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -53,8 +53,8 @@ async fn find_free_port_in_range(start: u16, end: u16) -> Option<u16> {
 
 pub struct StartFlag(pub Arc<tokio::sync::Notify>);
 
-impl TNotifyStartUpWatier for StartFlag {
-    fn notify_startup_waiter(&self) {
+impl TNotifyStartUp for StartFlag {
+    fn notify_startup(&self) {
         self.0.notify_one();
     }
 }

--- a/tests/test_config_get_dir.rs
+++ b/tests/test_config_get_dir.rs
@@ -4,8 +4,7 @@
 /// if the value of dir is /tmp, then the expected response to CONFIG GET dir is:
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 mod common;
-use common::{integration_test_config, TestStreamHandler};
-use redis_starter_rust::{adapters::persistence::EnDecoder, start_up};
+use common::{integration_test_config, start_test_server, TestStreamHandler};
 
 use tokio::net::TcpStream;
 
@@ -15,10 +14,10 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    tokio::spawn(start_up(config, 3, EnDecoder));
-    //warm up time
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    let _ = start_test_server(config).await;
+
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
+
     let mut h: TestStreamHandler = client_stream.split().into();
 
     // WHEN

--- a/tests/test_keys.rs
+++ b/tests/test_keys.rs
@@ -1,14 +1,14 @@
 mod common;
-use common::{integration_test_config, TestStreamHandler};
-use redis_starter_rust::{adapters::persistence::EnDecoder, start_up};
+use common::{integration_test_config, start_test_server, TestStreamHandler};
 use tokio::net::TcpStream;
 
 #[tokio::test]
 async fn test() {
     // GIVEN
     let config = integration_test_config().await;
-    tokio::spawn(start_up(config, 3, EnDecoder));
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    let _ = start_test_server(config).await;
+
     let mut stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = stream.split().into();
     let num_of_keys = 500;

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -4,9 +4,7 @@
 /// if the value of dir is /tmp, then the expected response to CONFIG GET dir is:
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 mod common;
-use common::{integration_test_config, TestStreamHandler};
-use redis_starter_rust::{adapters::persistence::EnDecoder, start_up};
-
+use common::{integration_test_config, start_test_server, TestStreamHandler};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -15,9 +13,8 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    tokio::spawn(start_up(config, 3, EnDecoder));
-    //warm up time
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    let _ = start_test_server(config).await;
+
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();
 

--- a/tests/test_set_get.rs
+++ b/tests/test_set_get.rs
@@ -3,9 +3,7 @@
 /// Then we get the key and check if the value is returned
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 mod common;
-use common::{integration_test_config, TestStreamHandler};
-use redis_starter_rust::{adapters::persistence::EnDecoder, start_up};
-
+use common::{integration_test_config, start_test_server, TestStreamHandler};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -13,9 +11,8 @@ async fn test() {
     // GIVEN
     let config = integration_test_config().await;
 
-    tokio::spawn(start_up(config, 3, EnDecoder));
-    //warm up time
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    let _ = start_test_server(config).await;
+
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();
 


### PR DESCRIPTION
`TNotifyStartupWaiter` is defined to signal each binary that server is up and running.

This is to reduce warm up delay