### PR TITLE
feat: cancellation token 

### DIFF
--- a/src/adapters/cancellation_token.rs
+++ b/src/adapters/cancellation_token.rs
@@ -1,0 +1,34 @@
+use crate::services::query_manager::interface::{
+    TCancellationNotifier, TCancellationTokenFactory, TCancellationWatcher,
+};
+
+pub struct CancellationToken {
+    sender: tokio::sync::oneshot::Sender<()>,
+    receiver: tokio::sync::oneshot::Receiver<()>,
+}
+impl TCancellationTokenFactory for CancellationToken {
+    fn create() -> Self {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        Self {
+            sender: tx,
+            receiver: rx,
+        }
+    }
+    fn split(self) -> (impl TCancellationNotifier, impl TCancellationWatcher) {
+        (self.sender, self.receiver)
+    }
+}
+
+impl TCancellationWatcher for tokio::sync::oneshot::Receiver<()> {
+    fn watch(&mut self) -> bool {
+        self.try_recv().is_ok()
+    }
+}
+impl TCancellationNotifier for tokio::sync::oneshot::Sender<()> {
+    fn notify(self, millis: u64) {
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(millis)).await;
+            let _ = self.send(());
+        });
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,1 +1,2 @@
+pub mod cancellation_token;
 pub mod persistence;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use config::Config;
 use services::{
     interfaces::endec::TEnDecoder,
     query_manager::{
-        interface::{TCancelNotifier, TCancellationTokenFactory, TCancellationWatcher},
+        interface::{TCancelNotifier, TCancellationTokenFactory},
         QueryManager,
     },
     statefuls::routers::{cache_manager::CacheManager, ttl_manager::TtlSchedulerInbox},
@@ -22,10 +22,7 @@ pub async fn start_up<T: TCancellationTokenFactory>(
     number_of_cache_actors: usize,
     endec: impl TEnDecoder,
     startup_notifier: impl TNotifyStartUp,
-) -> Result<()>
-where
-    T: TCancellationTokenFactory,
-{
+) -> Result<()> {
     let (cache_dispatcher, ttl_inbox) =
         CacheManager::run_cache_actors(number_of_cache_actors, endec);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@ use anyhow::Result;
 use config::Config;
 use services::{
     interfaces::endec::TEnDecoder,
-    query_manager::QueryManager,
+    query_manager::{
+        interface::{TCancelNotifier, TCancellationTokenFactory, TCancellationWatcher},
+        QueryManager,
+    },
     statefuls::routers::{cache_manager::CacheManager, ttl_manager::TtlSchedulerInbox},
 };
 use std::time::SystemTime;
@@ -14,12 +17,17 @@ use tokio::net::{TcpListener, TcpStream};
 
 /// dir, dbfilename is given as follows: ./your_program.sh --dir /tmp/redis-files --dbfilename dump.rdb
 
-pub async fn start_up(
+pub async fn start_up<T: TCancellationTokenFactory<N, W>, N, W>(
     config: &'static Config,
     number_of_cache_actors: usize,
     endec: impl TEnDecoder,
     startup_notifier: impl TNotifyStartUp,
-) -> Result<()> {
+) -> Result<()>
+where
+    T: TCancellationTokenFactory<N, W>,
+    N: TCancelNotifier,
+    W: TCancellationWatcher,
+{
     let (cache_dispatcher, ttl_inbox) =
         CacheManager::run_cache_actors(number_of_cache_actors, endec);
 
@@ -36,22 +44,35 @@ pub async fn start_up(
             // Spawn a new task to handle the connection without blocking the main thread.
             {
                 let query_manager = QueryManager::new(socket, config);
-                process_socket(query_manager, ttl_inbox.clone(), cache_dispatcher.clone())
+                process_socket::<_, T, N, W>(
+                    query_manager,
+                    ttl_inbox.clone(),
+                    cache_dispatcher.clone(),
+                );
             }
             Err(e) => eprintln!("Failed to accept connection: {:?}", e),
         }
     }
 }
 
-fn process_socket<T: TEnDecoder>(
+fn process_socket<T: TEnDecoder, U: TCancellationTokenFactory<N, W>, N, W>(
     mut query_manager: QueryManager<TcpStream>,
     ttl_inbox: TtlSchedulerInbox,
     cache_dispatcher: CacheManager<T>,
-) {
+) where
+    U: TCancellationTokenFactory<N, W>,
+    N: TCancelNotifier,
+    W: TCancellationWatcher,
+{
     tokio::spawn(async move {
         loop {
+            let (tx, rx) = U::create();
+            tokio::spawn(async move {
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                tx.notify();
+            });
             if let Err(e) = query_manager
-                .handle(&cache_dispatcher, ttl_inbox.clone())
+                .handle(&cache_dispatcher, ttl_inbox.clone(), rx)
                 .await
             {
                 eprintln!("Error: {:?}", e);
@@ -65,6 +86,7 @@ fn process_socket<T: TEnDecoder>(
 pub trait TNotifyStartUp {
     fn notify_startup(&self);
 }
+
 impl TNotifyStartUp for () {
     fn notify_startup(&self) {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use std::sync::OnceLock;
 
 use redis_starter_rust::{
-    adapters::persistence::EnDecoder, config::Config,
-    services::query_manager::interface::CancellationToken, start_up,
+    adapters::{cancellation_token::CancellationToken, persistence::EnDecoder},
+    config::Config,
+    start_up,
 };
 
 const NUM_OF_PERSISTENCE: usize = 10;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,15 @@ const NUM_OF_PERSISTENCE: usize = 10;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    start_up(config(), NUM_OF_PERSISTENCE, EnDecoder, ()).await
+    start_up::<
+        (
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        ),
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    >(config(), NUM_OF_PERSISTENCE, EnDecoder, ())
+    .await
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,15 @@
 use std::sync::OnceLock;
 
-use redis_starter_rust::{adapters::persistence::EnDecoder, config::Config, start_up};
+use redis_starter_rust::{
+    adapters::persistence::EnDecoder, config::Config,
+    services::query_manager::interface::CancellationToken, start_up,
+};
 
 const NUM_OF_PERSISTENCE: usize = 10;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    start_up::<
-        (
-            tokio::sync::oneshot::Sender<()>,
-            tokio::sync::oneshot::Receiver<()>,
-        ),
-        tokio::sync::oneshot::Sender<()>,
-        tokio::sync::oneshot::Receiver<()>,
-    >(config(), NUM_OF_PERSISTENCE, EnDecoder, ())
-    .await
+    start_up::<CancellationToken>(config(), NUM_OF_PERSISTENCE, EnDecoder, ()).await
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ const NUM_OF_PERSISTENCE: usize = 10;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // bootstrap dependencies
     start_up::<CancellationToken>(config(), NUM_OF_PERSISTENCE, EnDecoder, ()).await
 }
 

--- a/src/services/query_manager/interface.rs
+++ b/src/services/query_manager/interface.rs
@@ -58,13 +58,6 @@ impl TWriteBuf for tokio::net::TcpStream {
     }
 }
 
-pub struct CancelNotifier {
-    notifier: Option<tokio::sync::oneshot::Sender<()>>,
-}
-pub struct CancellationWatcher {
-    receiver: tokio::sync::oneshot::Receiver<()>,
-}
-
 pub trait TCancellationTokenFactory<T, U>
 where
     T: TCancelNotifier,

--- a/src/services/query_manager/mod.rs
+++ b/src/services/query_manager/mod.rs
@@ -37,10 +37,15 @@ where
         &mut self,
         persistence_router: &CacheManager<EnDec>,
         ttl_sender: TtlSchedulerInbox,
+        mut cancellation_token: impl interface::TCancellationWatcher,
     ) -> Result<()> {
         let Some((cmd, args)) = self.read_value().await? else {
             return Err(anyhow::anyhow!("Connection closed"));
         };
+
+        if cancellation_token.watch() {
+            return Err(anyhow::anyhow!("Cancellation token activated"));
+        }
 
         // TODO if it is persistence operation, get the key and hash, take the appropriate sender, send it;
         let response = match cmd {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,5 @@
 use redis_starter_rust::{
-    config::Config,
-    services::query_manager::interface::{
-        TCancelNotifier, TCancellationTokenFactory, TCancellationWatcher,
-    },
-    TNotifyStartUp,
+    config::Config, services::query_manager::interface::TCancellationTokenFactory, TNotifyStartUp,
 };
 use std::sync::{Arc, OnceLock};
 use tokio::{

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -65,18 +65,13 @@ impl TNotifyStartUp for StartFlag {
     }
 }
 
-pub async fn start_test_server<T: TCancellationTokenFactory<N, W>, N, W>(
+pub async fn start_test_server<T: TCancellationTokenFactory>(
     config: &'static Config,
-) -> tokio::task::JoinHandle<Result<(), anyhow::Error>>
-where
-    T: TCancellationTokenFactory<N, W>,
-    N: TCancelNotifier,
-    W: TCancellationWatcher,
-{
+) -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
     // GIVEN
     let notify = Arc::new(tokio::sync::Notify::new());
     let start_flag = StartFlag(notify.clone());
-    let h = tokio::spawn(redis_starter_rust::start_up::<T, N, W>(
+    let h = tokio::spawn(redis_starter_rust::start_up::<T>(
         config,
         3,
         redis_starter_rust::adapters::persistence::EnDecoder,

--- a/tests/test_cancellation_token.rs
+++ b/tests/test_cancellation_token.rs
@@ -1,0 +1,55 @@
+/// The following is to test out the set operation with expiry
+/// Firstly, we set a key with a value and an expiry of 300ms
+/// Then we get the key and check if the value is returned
+/// After 300ms, we get the key again and check if the value is not returned (-1)
+mod common;
+use common::{integration_test_config, start_test_server, TestStreamHandler};
+use redis_starter_rust::services::query_manager::interface::{
+    TCancellationNotifier, TCancellationTokenFactory, TCancellationWatcher,
+};
+use tokio::net::TcpStream;
+
+#[tokio::test]
+async fn test_cancellation_token() {
+    // GIVEN
+    let config = integration_test_config().await;
+
+    let _ = start_test_server::<TestCancellationToken>(config).await;
+
+    let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
+    let mut h: TestStreamHandler = client_stream.split().into();
+
+    // WHEN
+    h.send(b"*5\r\n$3\r\nSET\r\n$10\r\nsomanyrand\r\n$3\r\nbar\r\n$2\r\npx\r\n$3\r\n300\r\n")
+        .await;
+
+    // THEN
+    assert_eq!(
+        h.get_response().await,
+        "-Error opertation cancelled due to timeout\r\n"
+    );
+}
+
+pub struct TestCancellationToken {
+    sender: TestNotifier,
+    receiver: tokio::sync::oneshot::Receiver<()>,
+}
+impl TCancellationTokenFactory for TestCancellationToken {
+    fn create() -> Self {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        Self {
+            sender: TestNotifier(tx),
+            receiver: rx,
+        }
+    }
+    fn split(self) -> (impl TCancellationNotifier, impl TCancellationWatcher) {
+        (self.sender, self.receiver)
+    }
+}
+
+struct TestNotifier(tokio::sync::oneshot::Sender<()>);
+impl TCancellationNotifier for TestNotifier {
+    fn notify(self, _millis: u64) {
+        let _ = self.0.send(());
+    }
+}

--- a/tests/test_config_get_dir.rs
+++ b/tests/test_config_get_dir.rs
@@ -6,7 +6,7 @@
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
 
-use redis_starter_rust::services::query_manager::interface::CancellationToken;
+use redis_starter_rust::adapters::cancellation_token::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]

--- a/tests/test_config_get_dir.rs
+++ b/tests/test_config_get_dir.rs
@@ -6,6 +6,7 @@
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
 
+use redis_starter_rust::services::query_manager::interface::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -14,15 +15,7 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    let _ = start_test_server::<
-        (
-            tokio::sync::oneshot::Sender<()>,
-            tokio::sync::oneshot::Receiver<()>,
-        ),
-        tokio::sync::oneshot::Sender<()>,
-        tokio::sync::oneshot::Receiver<()>,
-    >(config)
-    .await;
+    let _ = start_test_server::<CancellationToken>(config).await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
 

--- a/tests/test_config_get_dir.rs
+++ b/tests/test_config_get_dir.rs
@@ -14,7 +14,15 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    let _ = start_test_server(config).await;
+    let _ = start_test_server::<
+        (
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        ),
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    >(config)
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
 

--- a/tests/test_keys.rs
+++ b/tests/test_keys.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
+use redis_starter_rust::services::query_manager::interface::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -7,15 +8,7 @@ async fn test() {
     // GIVEN
     let config = integration_test_config().await;
 
-    let _ = start_test_server::<
-        (
-            tokio::sync::oneshot::Sender<()>,
-            tokio::sync::oneshot::Receiver<()>,
-        ),
-        tokio::sync::oneshot::Sender<()>,
-        tokio::sync::oneshot::Receiver<()>,
-    >(config)
-    .await;
+    let _ = start_test_server::<CancellationToken>(config).await;
 
     let mut stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = stream.split().into();

--- a/tests/test_keys.rs
+++ b/tests/test_keys.rs
@@ -7,7 +7,15 @@ async fn test() {
     // GIVEN
     let config = integration_test_config().await;
 
-    let _ = start_test_server(config).await;
+    let _ = start_test_server::<
+        (
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        ),
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    >(config)
+    .await;
 
     let mut stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = stream.split().into();

--- a/tests/test_keys.rs
+++ b/tests/test_keys.rs
@@ -1,6 +1,7 @@
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
-use redis_starter_rust::services::query_manager::interface::CancellationToken;
+
+use redis_starter_rust::adapters::cancellation_token::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -5,7 +5,8 @@
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
-use redis_starter_rust::services::query_manager::interface::CancellationToken;
+
+use redis_starter_rust::adapters::cancellation_token::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -13,7 +13,15 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    let _ = start_test_server(config).await;
+    start_test_server::<
+        (
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        ),
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    >(config)
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -5,6 +5,7 @@
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
+use redis_starter_rust::services::query_manager::interface::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -13,15 +14,7 @@ async fn test() {
     //TODO test config should be dynamically configured
     let config = integration_test_config().await;
 
-    start_test_server::<
-        (
-            tokio::sync::oneshot::Sender<()>,
-            tokio::sync::oneshot::Receiver<()>,
-        ),
-        tokio::sync::oneshot::Sender<()>,
-        tokio::sync::oneshot::Receiver<()>,
-    >(config)
-    .await;
+    start_test_server::<CancellationToken>(config).await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_set_get.rs
+++ b/tests/test_set_get.rs
@@ -4,6 +4,7 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
+use redis_starter_rust::services::query_manager::interface::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -11,15 +12,7 @@ async fn test() {
     // GIVEN
     let config = integration_test_config().await;
 
-    let _ = start_test_server::<
-        (
-            tokio::sync::oneshot::Sender<()>,
-            tokio::sync::oneshot::Receiver<()>,
-        ),
-        tokio::sync::oneshot::Sender<()>,
-        tokio::sync::oneshot::Receiver<()>,
-    >(config)
-    .await;
+    let _ = start_test_server::<CancellationToken>(config).await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_set_get.rs
+++ b/tests/test_set_get.rs
@@ -11,7 +11,15 @@ async fn test() {
     // GIVEN
     let config = integration_test_config().await;
 
-    let _ = start_test_server(config).await;
+    let _ = start_test_server::<
+        (
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        ),
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    >(config)
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_set_get.rs
+++ b/tests/test_set_get.rs
@@ -4,7 +4,8 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 mod common;
 use common::{integration_test_config, start_test_server, TestStreamHandler};
-use redis_starter_rust::services::query_manager::interface::CancellationToken;
+
+use redis_starter_rust::adapters::cancellation_token::CancellationToken;
 use tokio::net::TcpStream;
 
 #[tokio::test]


### PR DESCRIPTION
Cancellation token implemented.

Exactly when and how it will be used will be decided later. 

traits defined within `query_manager` may be relocated to service interface if it becomes cross-functional concern. 