### PR TITLE
refactor: startup facade

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,142 +15,128 @@ use services::statefuls::cache::cache_manager::CacheManager;
 use services::statefuls::cache::ttl_manager::TtlSchedulerInbox;
 use services::statefuls::persist::persist_actor::PersistActor;
 
-// TODO should replica be able to receive replica traffics directly?
-async fn start_accepting_peer_connections(
-    connect_stream_factory: impl TConnectStreamFactory,
-    replication_listener: impl TStreamListener,
-    config_manager: ConfigManager,
-) {
-    let replication_request_controller: &'static ReplicationRequestController =
-        Box::leak(ReplicationRequestController::new(config_manager.clone()).into());
-
-    loop {
-        match replication_listener.listen().await {
-            Ok((peer_stream, _)) => {
-                tokio::spawn(QueryManager::handle_peer_stream(
-                    connect_stream_factory,
-                    peer_stream,
-                    replication_request_controller,
-                ));
-            }
-
-            Err(err) => {
-                if err.should_break() {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-// TODO should replica be able to receive client traffics directly?
-async fn start_accepting_client_connections(
-    cancellation_factory: impl TCancellationTokenFactory,
-    client_stream_listener: impl TStreamListener,
-    cache_manager: &'static CacheManager,
-    ttl_inbox: TtlSchedulerInbox,
-    config_manager: ConfigManager,
-) {
-    // SAFETY: The client_request_controller is leaked to make it static.
-    // This is safe because the client_request_controller will live for the entire duration of the program.
-    let client_request_controller: &'static ClientRequestController =
-        Box::leak(ClientRequestController::new(config_manager, cache_manager, ttl_inbox).into());
-
-    loop {
-        match client_stream_listener.listen().await {
-            Ok((stream, _)) =>
-            // Spawn a new task to handle the connection without blocking the main thread.
-            {
-                tokio::spawn(
-                    QueryManager::handle_single_client_stream::<tokio::fs::File>(
-                        cancellation_factory,
-                        stream,
-                        client_request_controller,
-                    ),
-                );
-            }
-            Err(e) => {
-                if e.should_break() {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-pub struct StartUpFacade<T, U, V, K> {
+// * StartUp Facade that manages invokes subsystems
+pub struct StartUpFacade<T, U, V> {
     connect_stream_factory: T,
     stream_listener: U,
     cancellation_factory: V,
-    config: Config,
-    startup_notifier: K,
+    ttl_inbox: TtlSchedulerInbox,
+    cache_manager: &'static CacheManager,
+    client_request_controller: &'static ClientRequestController,
+    replication_request_controller: &'static ReplicationRequestController,
 }
 
-impl<T, U, V, K> StartUpFacade<T, U, V, K>
+impl<T, U, V> StartUpFacade<T, U, V>
 where
     T: TConnectStreamFactory,
     U: TStreamListenerFactory,
     V: TCancellationTokenFactory,
-    K: TNotifyStartUp,
 {
     pub fn new(
         connect_stream_factory: T,
         stream_listener: U,
         cancellation_factory: V,
         config: Config,
-        startup_notifier: K,
     ) -> Self {
-        StartUpFacade {
-            connect_stream_factory,
-            stream_listener,
-            cancellation_factory,
-            config,
-            startup_notifier,
-        }
-    }
-
-    pub async fn run(&self) -> Result<()> {
-        let replication_stream_listener = self
-            .stream_listener
-            .create_listner(self.config.replication_bind_addr())
-            .await;
-        let client_stream_listener = self
-            .stream_listener
-            .create_listner(self.config.bind_addr())
-            .await;
-
         let (cache_manager, ttl_inbox) = CacheManager::run_cache_actors();
-
-        if let Some(filepath) = self.config.try_filepath().await {
-            let dump = PersistActor::dump(filepath).await?;
-            cache_manager
-                .dump_cache(dump, ttl_inbox.clone(), self.config.startup_time)
-                .await?;
-        }
-
-        // Run Replication manager
-        let config_manager = ConfigManager::run_actor(self.config.clone());
+        let config_manager = ConfigManager::run_actor(config.clone());
 
         // Leak the cache_dispatcher to make it static - this is safe because the cache_dispatcher
         // will live for the entire duration of the program.
         let cache_manager: &'static CacheManager = Box::leak(Box::new(cache_manager));
+        let client_request_controller: &'static ClientRequestController = Box::leak(
+            ClientRequestController::new(config_manager.clone(), cache_manager, ttl_inbox.clone())
+                .into(),
+        );
+        let replication_request_controller: &'static ReplicationRequestController =
+            Box::leak(ReplicationRequestController::new(config_manager.clone()).into());
 
-        tokio::spawn(start_accepting_peer_connections(
-            self.connect_stream_factory,
-            replication_stream_listener,
-            config_manager.clone(),
-        ));
-        self.startup_notifier.notify_startup();
-
-        start_accepting_client_connections(
-            self.cancellation_factory,
-            client_stream_listener,
+        StartUpFacade {
+            connect_stream_factory,
+            stream_listener,
+            cancellation_factory,
             cache_manager,
             ttl_inbox,
-            config_manager,
-        )
-        .await;
+            client_request_controller,
+            replication_request_controller,
+        }
+    }
+
+    // TODO: remove input config and use config manager
+    pub async fn run(&self, startup_notifier: impl TNotifyStartUp, config: Config) -> Result<()> {
+        if let Some(filepath) = config.try_filepath().await {
+            let dump = PersistActor::dump(filepath).await?;
+            self.cache_manager
+                .dump_cache(dump, self.ttl_inbox.clone(), config.startup_time)
+                .await?;
+        }
+
+        self.start_accepting_peer_connections(config.peer_bind_addr())
+            .await;
+
+        self.start_accepting_client_connections(config.bind_addr(), startup_notifier)
+            .await;
         Ok(())
+    }
+
+    async fn start_accepting_peer_connections(&self, replication_bind_addr: String) {
+        let replication_listener = self
+            .stream_listener
+            .create_listner(replication_bind_addr)
+            .await;
+        let connect_stream_factory = self.connect_stream_factory;
+        let replication_request_controller = self.replication_request_controller;
+
+        tokio::spawn(async move {
+            loop {
+                match replication_listener.listen().await {
+                    Ok((peer_stream, _)) => {
+                        tokio::spawn(QueryManager::handle_peer_stream(
+                            connect_stream_factory,
+                            peer_stream,
+                            replication_request_controller,
+                        ));
+                    }
+
+                    Err(err) => {
+                        if err.should_break() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    async fn start_accepting_client_connections(
+        &self,
+        bind_addr: String,
+        startup_notifier: impl TNotifyStartUp,
+    ) {
+        // SAFETY: The client_request_controller is leaked to make it static.
+        // This is safe because the client_request_controller will live for the entire duration of the program.
+        let client_stream_listener = self.stream_listener.create_listner(bind_addr).await;
+        startup_notifier.notify_startup();
+        loop {
+            match client_stream_listener.listen().await {
+                Ok((stream, _)) =>
+                // Spawn a new task to handle the connection without blocking the main thread.
+                {
+                    tokio::spawn(
+                        QueryManager::handle_single_client_stream::<tokio::fs::File>(
+                            self.cancellation_factory,
+                            stream,
+                            self.client_request_controller,
+                        ),
+                    );
+                }
+                Err(e) => {
+                    if e.should_break() {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,19 +4,20 @@ use redis_starter_rust::{
         io::tokio_stream::{TokioConnectStreamFactory, TokioStreamListenerFactory},
     },
     services::config::config_actor::Config,
-    start_up,
+    StartUpFacade,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // bootstrap dependencies
     let config = Config::default();
-    start_up(
+
+    let start_up_runner = StartUpFacade::new(
         TokioConnectStreamFactory,
         TokioStreamListenerFactory,
         CancellationTokenFactory,
         config,
         (),
-    )
-    .await
+    );
+    start_up_runner.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,7 @@ async fn main() -> anyhow::Result<()> {
         TokioConnectStreamFactory,
         TokioStreamListenerFactory,
         CancellationTokenFactory,
-        config,
-        (),
+        config.clone(),
     );
-    start_up_runner.run().await
+    start_up_runner.run((), config).await
 }

--- a/src/services/config/config_actor.rs
+++ b/src/services/config/config_actor.rs
@@ -52,11 +52,12 @@ impl Config {
         }
     }
 
+    //TODO this is immutable! Should be moved to manager
     pub fn bind_addr(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
-    pub fn replication_bind_addr(&self) -> String {
-        // TODO basic validation required for port number so it doesn't go over 65535
+    //TODO this is immutable! Should be moved to manager
+    pub fn peer_bind_addr(&self) -> String {
         format!("{}:{}", self.host, self.port + 10000)
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -83,12 +83,11 @@ pub async fn start_test_server(
         TokioConnectStreamFactory,
         TokioStreamListenerFactory,
         cancellation_token_factory,
-        config,
-        start_flag,
+        config.clone(),
     );
 
     let h = tokio::spawn(async move {
-        start_up_facade.run().await?;
+        start_up_facade.run(start_flag, config).await?;
         Ok(())
     });
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,10 +1,10 @@
 use redis_starter_rust::adapters::io::tokio_stream::TokioConnectStreamFactory;
 use redis_starter_rust::services::query_manager::interface::TCancellationTokenFactory;
 use redis_starter_rust::services::query_manager::query_io::QueryIO;
-use redis_starter_rust::TNotifyStartUp;
 use redis_starter_rust::{
     adapters::io::tokio_stream::TokioStreamListenerFactory, services::config::config_actor::Config,
 };
+use redis_starter_rust::{StartUpFacade, TNotifyStartUp};
 
 use std::sync::Arc;
 use tokio::{
@@ -79,13 +79,18 @@ pub async fn start_test_server(
     let notify = Arc::new(tokio::sync::Notify::new());
     let start_flag = StartFlag(notify.clone());
 
-    let h = tokio::spawn(redis_starter_rust::start_up(
+    let start_up_facade = StartUpFacade::new(
         TokioConnectStreamFactory,
         TokioStreamListenerFactory,
         cancellation_token_factory,
         config,
         start_flag,
-    ));
+    );
+
+    let h = tokio::spawn(async move {
+        start_up_facade.run().await?;
+        Ok(())
+    });
 
     //warm up time
     notify.notified().await;


### PR DESCRIPTION
There is increasing need for passing dependencies, each of which can be entire subsystem, to `start_up` function. 

And then it manages lifecycles, bootstrapping and the like. 

Before it gets bigger and bigger, I figured structural design should be introduced. 