### PR TITLE
feat: cluster manager outlined

### DIFF
--- a/src/adapters/io/tokio_stream.rs
+++ b/src/adapters/io/tokio_stream.rs
@@ -1,15 +1,16 @@
-use std::io::ErrorKind;
-
 use crate::{
-    services::stream_manager::{
-        error::IoError,
-        interface::{TConnectStreamFactory, TGetPeerIp, TRead, TStream},
-        query_io::{parse, QueryIO},
-        PeerAddr,
+    services::{
+        cluster::PeerAddr,
+        stream_manager::{
+            error::IoError,
+            interface::{TConnectStreamFactory, TGetPeerIp, TRead, TStream},
+            query_io::{parse, QueryIO},
+        },
     },
     TStreamListener, TStreamListenerFactory,
 };
 use bytes::BytesMut;
+use std::io::ErrorKind;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,

--- a/src/adapters/io/tokio_stream.rs
+++ b/src/adapters/io/tokio_stream.rs
@@ -1,6 +1,6 @@
 use crate::{
     services::{
-        cluster::PeerAddr,
+        cluster::actor::PeerAddr,
         stream_manager::{
             error::IoError,
             interface::{TConnectStreamFactory, TGetPeerIp, TRead, TStream},

--- a/src/adapters/io/tokio_stream.rs
+++ b/src/adapters/io/tokio_stream.rs
@@ -1,19 +1,16 @@
-use crate::{
-    services::{
-        cluster::actor::PeerAddr,
-        stream_manager::{
-            client_request_controllers::{
-                arguments::ClientRequestArguments, client_request::ClientRequest,
-            },
-            error::IoError,
-            interface::{TConnectStreamFactory, TExtractQuery, TGetPeerIp, TRead, TStream},
-            query_io::{parse, QueryIO},
-            replication_request_controllers::{
-                arguments::PeerRequestArguments, replication_request::HandShakeRequest,
-            },
+use crate::services::{
+    cluster::actor::PeerAddr,
+    stream_manager::{
+        client_request_controllers::{
+            arguments::ClientRequestArguments, client_request::ClientRequest,
+        },
+        error::IoError,
+        interface::{TConnectStreamFactory, TExtractQuery, TGetPeerIp, TRead, TStream},
+        query_io::{parse, QueryIO},
+        replication_request_controllers::{
+            arguments::PeerRequestArguments, replication_request::HandShakeRequest,
         },
     },
-    TStreamListener, TStreamListenerFactory,
 };
 use anyhow::Context;
 use bytes::BytesMut;
@@ -142,18 +139,9 @@ impl TGetPeerIp for tokio::net::TcpStream {
     }
 }
 
-impl TStreamListener<TcpStream> for TcpListener {
-    async fn listen(&self) -> std::result::Result<(TcpStream, std::net::SocketAddr), IoError> {
-        match self.accept().await {
-            Ok(val) => Ok((val.0, val.1)),
-            Err(err) => Err(err.kind().into()),
-        }
-    }
-}
-
 pub struct TokioStreamListenerFactory;
-impl TStreamListenerFactory<TcpStream> for TokioStreamListenerFactory {
-    async fn create_listner(&self, bind_addr: String) -> impl TStreamListener<TcpStream> {
+impl TokioStreamListenerFactory {
+    pub async fn create_listner(&self, bind_addr: String) -> TcpListener {
         TcpListener::bind(bind_addr).await.expect("failed to bind")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use services::stream_manager::interface::{
     TCancellationTokenFactory, TConnectStreamFactory, TExtractQuery, TStream, TStreamListener,
     TStreamListenerFactory,
 };
+use services::stream_manager::replication_request_controllers::arguments::PeerRequestArguments;
+use services::stream_manager::replication_request_controllers::replication_request::HandShakeRequest;
 use services::stream_manager::replication_request_controllers::ReplicationRequestController;
 use services::stream_manager::StreamManager;
 
@@ -41,7 +43,9 @@ where
     T: TConnectStreamFactory<S>,
     U: TStreamListenerFactory<S>,
     V: TCancellationTokenFactory,
-    S: TStream + TExtractQuery<ClientRequest, ClientRequestArguments>,
+    S: TStream
+        + TExtractQuery<ClientRequest, ClientRequestArguments>
+        + TExtractQuery<HandShakeRequest, PeerRequestArguments>,
 {
     pub fn new(
         connect_stream_factory: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,8 @@ where
         Ok(())
     }
 
-    async fn start_accepting_peer_connections(&self, replication_bind_addr: String) {
-        let replication_listener = self
-            .stream_listener
-            .create_listner(replication_bind_addr)
-            .await;
+    async fn start_accepting_peer_connections(&self, peer_bind_addr: String) {
+        let replication_listener = self.stream_listener.create_listner(peer_bind_addr).await;
         let connect_stream_factory = self.connect_stream_factory;
         let replication_request_controller = self.replication_request_controller;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,59 +2,45 @@ pub mod adapters;
 pub mod macros;
 pub mod services;
 use crate::services::stream_manager::client_request_controllers::ClientRequestController;
+use adapters::io::tokio_stream::{TokioConnectStreamFactory, TokioStreamListenerFactory};
 use anyhow::Result;
+use services::cluster::actor::ClusterActor;
 use services::cluster::ClusterManager;
 use services::config::config_manager::ConfigManager;
 
 use services::statefuls::cache::cache_manager::CacheManager;
 use services::statefuls::cache::ttl_manager::TtlSchedulerInbox;
 use services::statefuls::persist::persist_actor::PersistActor;
-use services::stream_manager::client_request_controllers::arguments::ClientRequestArguments;
-use services::stream_manager::client_request_controllers::client_request::ClientRequest;
-use services::stream_manager::interface::{
-    TCancellationTokenFactory, TConnectStreamFactory, TExtractQuery, TStream, TStreamListener,
-    TStreamListenerFactory,
-};
-use services::stream_manager::replication_request_controllers::arguments::PeerRequestArguments;
-use services::stream_manager::replication_request_controllers::replication_request::HandShakeRequest;
-use services::stream_manager::replication_request_controllers::ReplicationRequestController;
+
+use services::stream_manager::error::IoError;
+use services::stream_manager::interface::TCancellationTokenFactory;
 use services::stream_manager::StreamManager;
 
 // * StartUp Facade that manages invokes subsystems
-pub struct StartUpFacade<T, U, V, S>
+pub struct StartUpFacade<V>
 where
-    U: TStreamListenerFactory<S>,
     V: TCancellationTokenFactory,
-    S: TStream + TExtractQuery<ClientRequest, ClientRequestArguments>,
 {
-    connect_stream_factory: T,
-    stream_listener: U,
     cancellation_factory: V,
     ttl_inbox: TtlSchedulerInbox,
     cache_manager: &'static CacheManager,
     client_request_controller: &'static ClientRequestController,
-    replication_request_controller: &'static ReplicationRequestController,
     config_manager: ConfigManager,
-    cluster_manager: &'static ClusterManager<S>,
+    cluster_manager: &'static ClusterManager,
 }
 
-impl<T, U, V, S> StartUpFacade<T, U, V, S>
+impl<V> StartUpFacade<V>
 where
-    T: TConnectStreamFactory<S>,
-    U: TStreamListenerFactory<S>,
     V: TCancellationTokenFactory,
-    S: TStream
-        + TExtractQuery<ClientRequest, ClientRequestArguments>
-        + TExtractQuery<HandShakeRequest, PeerRequestArguments>,
 {
     pub fn new(
-        connect_stream_factory: T,
-        stream_listener: U,
         cancellation_factory: V,
         config_manager: ConfigManager,
+        cluster_actor: ClusterActor,
     ) -> Self {
         let (cache_manager, ttl_inbox) = CacheManager::run_cache_actors();
-        let cluster_manager: &'static ClusterManager<S> = Box::leak(ClusterManager::run().into());
+        let cluster_manager: &'static ClusterManager =
+            Box::leak(ClusterManager::run(cluster_actor).into());
 
         // Leak the cache_dispatcher to make it static - this is safe because the cache_dispatcher
         // will live for the entire duration of the program.
@@ -63,17 +49,12 @@ where
             ClientRequestController::new(config_manager.clone(), cache_manager, ttl_inbox.clone())
                 .into(),
         );
-        let replication_request_controller: &'static ReplicationRequestController =
-            Box::leak(ReplicationRequestController::new(config_manager.clone()).into());
 
         StartUpFacade {
-            connect_stream_factory,
-            stream_listener,
             cancellation_factory,
             cache_manager,
             ttl_inbox,
             client_request_controller,
-            replication_request_controller,
             config_manager,
             cluster_manager,
         }
@@ -92,38 +73,39 @@ where
                 .await?;
         }
 
-        self.start_accepting_peer_connections(self.config_manager.peer_bind_addr())
-            .await;
+        tokio::spawn(Self::start_accepting_peer_connections(
+            self.config_manager.peer_bind_addr(),
+            self.cluster_manager,
+        ));
 
         self.start_accepting_client_connections(self.config_manager.bind_addr(), startup_notifier)
             .await;
         Ok(())
     }
 
-    async fn start_accepting_peer_connections(&self, peer_bind_addr: String) {
-        let peer_listener = self.stream_listener.create_listner(peer_bind_addr).await;
-        let connect_stream_factory = self.connect_stream_factory;
-        let replication_request_controller = self.replication_request_controller;
+    async fn start_accepting_peer_connections(
+        peer_bind_addr: String,
+        cluster_manager: &'static ClusterManager,
+    ) {
+        let peer_listener = TokioStreamListenerFactory
+            .create_listner(peer_bind_addr)
+            .await;
+        loop {
+            match peer_listener.accept().await {
+                // ? how do we know if incoming connection is from a peer or replica?
+                Ok((peer_stream, _socket_addr)) => {
+                    let query_manager = StreamManager::new(peer_stream, cluster_manager);
 
-        tokio::spawn(async move {
-            loop {
-                match peer_listener.listen().await {
-                    // ? how do we know if incoming connection is from a peer or replica?
-                    Ok((peer_stream, _socket_addr)) => {
-                        let query_manager =
-                            StreamManager::new(peer_stream, replication_request_controller);
+                    tokio::spawn(query_manager.handle_peer_stream(TokioConnectStreamFactory));
+                }
 
-                        tokio::spawn(query_manager.handle_peer_stream(connect_stream_factory));
-                    }
-
-                    Err(err) => {
-                        if err.should_break() {
-                            break;
-                        }
+                Err(err) => {
+                    if Into::<IoError>::into(err.kind()).should_break() {
+                        break;
                     }
                 }
             }
-        });
+        }
     }
 
     async fn start_accepting_client_connections(
@@ -133,10 +115,12 @@ where
     ) {
         // SAFETY: The client_request_controller is leaked to make it static.
         // This is safe because the client_request_controller will live for the entire duration of the program.
-        let client_stream_listener = self.stream_listener.create_listner(bind_addr).await;
+
+        let client_stream_listener = TokioStreamListenerFactory.create_listner(bind_addr).await;
+
         startup_notifier.notify_startup();
         loop {
-            match client_stream_listener.listen().await {
+            match client_stream_listener.accept().await {
                 Ok((stream, _)) =>
                 // Spawn a new task to handle the connection without blocking the main thread.
                 {
@@ -148,7 +132,7 @@ where
                     );
                 }
                 Err(e) => {
-                    if e.should_break() {
+                    if Into::<IoError>::into(e.kind()).should_break() {
                         break;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use redis_starter_rust::{
-    adapters::{
-        cancellation_token::CancellationTokenFactory,
-        io::tokio_stream::{TokioConnectStreamFactory, TokioStreamListenerFactory},
+    adapters::cancellation_token::CancellationTokenFactory,
+    services::{
+        cluster::actor::ClusterActor,
+        config::{config_actor::Config, config_manager::ConfigManager},
     },
-    services::config::{config_actor::Config, config_manager::ConfigManager},
     StartUpFacade,
 };
 
@@ -11,11 +11,8 @@ use redis_starter_rust::{
 async fn main() -> anyhow::Result<()> {
     // bootstrap dependencies
     let config_manager = ConfigManager::new(Config::default());
-    let start_up_runner = StartUpFacade::new(
-        TokioConnectStreamFactory,
-        TokioStreamListenerFactory,
-        CancellationTokenFactory,
-        config_manager,
-    );
+    let cluster_actor = ClusterActor::new();
+    let start_up_runner =
+        StartUpFacade::new(CancellationTokenFactory, config_manager, cluster_actor);
     start_up_runner.run(()).await
 }

--- a/src/services/cluster/actor.rs
+++ b/src/services/cluster/actor.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use tokio::sync::mpsc::Receiver;
+
+use crate::services::stream_manager::interface::TStream;
+
+use super::{ClusterCommand, Connected, PeerAddr};
+
+pub struct ClusterActor<T: TStream> {
+    peers: BTreeMap<PeerAddr, Connected<T>>,
+}
+
+impl<T: TStream> ClusterActor<T> {
+    pub fn new() -> Self {
+        Self {
+            peers: BTreeMap::new(),
+        }
+    }
+    pub fn add_peer(&mut self, peer_addr: PeerAddr, connected: Connected<T>) {
+        self.peers.insert(peer_addr, connected);
+    }
+
+    pub fn remove_peer(&mut self, peer_addr: PeerAddr) {
+        self.peers.remove(&peer_addr);
+    }
+
+    pub fn get_peer(&self, peer_addr: &PeerAddr) -> Option<&Connected<T>> {
+        self.peers.get(peer_addr)
+    }
+    pub async fn handle(mut self, mut recv: Receiver<ClusterCommand<T>>) {
+        while let Some(command) = recv.recv().await {
+            match command {
+                ClusterCommand::AddPeer(peer_addr, connected) => {
+                    self.add_peer(peer_addr, connected);
+                }
+                ClusterCommand::RemovePeer(peer_addr) => {
+                    self.remove_peer(peer_addr);
+                }
+                ClusterCommand::GetPeer(peer_addr) => {
+                    self.get_peer(&peer_addr);
+                }
+            }
+        }
+    }
+}

--- a/src/services/cluster/actor.rs
+++ b/src/services/cluster/actor.rs
@@ -4,10 +4,26 @@ use tokio::sync::mpsc::Receiver;
 
 use crate::services::stream_manager::interface::TStream;
 
-use super::{ClusterCommand, Connected, PeerAddr};
+pub enum ClusterCommand<T: TStream> {
+    AddPeer(PeerAddr, T),
+    RemovePeer(PeerAddr),
+    GetPeer(PeerAddr),
+}
 
 pub struct ClusterActor<T: TStream> {
     peers: BTreeMap<PeerAddr, Connected<T>>,
+}
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PeerAddr(pub String);
+
+pub enum Connected<T: TStream> {
+    Replica {
+        peer_stream: T,
+        replication_stream: T,
+    },
+    ClusterMemeber {
+        peer_stream: T,
+    },
 }
 
 impl<T: TStream> ClusterActor<T> {
@@ -16,9 +32,10 @@ impl<T: TStream> ClusterActor<T> {
             peers: BTreeMap::new(),
         }
     }
-    pub fn add_peer(&mut self, peer_addr: PeerAddr, connected: Connected<T>) {
-        self.peers.insert(peer_addr, connected);
-    }
+    // * Add peer to the cluster
+    // * This function is called when a new peer is connected to peer listener
+    // * Some are replicas and some are cluster members
+    pub fn add_peer(&mut self, peer_addr: PeerAddr, stream: T) {}
 
     pub fn remove_peer(&mut self, peer_addr: PeerAddr) {
         self.peers.remove(&peer_addr);

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -1,0 +1,68 @@
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use super::stream_manager::interface::TStream;
+use std::collections::BTreeMap;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PeerAddr(pub String);
+pub enum Connected<T: TStream> {
+    Replica {
+        peer_stream: T,
+        replication_stream: T,
+    },
+    ClusterMemeber {
+        peer_stream: T,
+    },
+}
+
+pub enum ClusterCommand<T: TStream> {
+    AddPeer(PeerAddr, Connected<T>),
+    RemovePeer(PeerAddr),
+    GetPeer(PeerAddr),
+}
+
+pub struct ClusterManager<T: TStream> {
+    peers: BTreeMap<PeerAddr, Connected<T>>,
+}
+
+impl<T: TStream> ClusterManager<T> {
+    pub fn new() -> Self {
+        Self {
+            peers: BTreeMap::new(),
+        }
+    }
+    pub fn add_peer(&mut self, peer_addr: PeerAddr, connected: Connected<T>) {
+        self.peers.insert(peer_addr, connected);
+    }
+
+    pub fn remove_peer(&mut self, peer_addr: PeerAddr) {
+        self.peers.remove(&peer_addr);
+    }
+
+    pub fn get_peer(&self, peer_addr: &PeerAddr) -> Option<&Connected<T>> {
+        self.peers.get(peer_addr)
+    }
+
+    pub fn run() -> Sender<ClusterCommand<T>> {
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let cluster_manager = ClusterManager::new();
+        tokio::spawn(cluster_manager.handle(rx));
+        tx
+    }
+
+    pub async fn handle(mut self, mut recv: Receiver<ClusterCommand<T>>) {
+        while let Some(command) = recv.recv().await {
+            match command {
+                ClusterCommand::AddPeer(peer_addr, connected) => {
+                    self.add_peer(peer_addr, connected);
+                }
+                ClusterCommand::RemovePeer(peer_addr) => {
+                    self.remove_peer(peer_addr);
+                }
+                ClusterCommand::GetPeer(peer_addr) => {
+                    self.get_peer(&peer_addr);
+                }
+            }
+        }
+    }
+}

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -1,16 +1,21 @@
 pub mod actor;
-use actor::{ClusterActor, ClusterCommand};
+use actor::{ClusterActor, ClusterCommand, PeerAddr};
 use tokio::sync::mpsc::Sender;
 
-use super::stream_manager::interface::TStream;
+#[derive(Clone)]
+pub struct ClusterManager(Sender<ClusterCommand>);
 
-pub struct ClusterManager<T: TStream>(Sender<ClusterCommand<T>>);
-
-impl<T: TStream> ClusterManager<T> {
-    pub fn run() -> Self {
+impl ClusterManager {
+    pub fn run(actor: ClusterActor) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
-        let cluster_manager = ClusterActor::new();
-        tokio::spawn(cluster_manager.handle(rx));
+        tokio::spawn(actor.handle(rx));
         Self(tx)
+    }
+
+    pub(crate) async fn get_peers(&self) -> anyhow::Result<Vec<PeerAddr>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.0.send(ClusterCommand::GetPeers(tx)).await?;
+        let peers = rx.await?;
+        Ok(peers)
     }
 }

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -1,26 +1,8 @@
 pub mod actor;
-use actor::ClusterActor;
+use actor::{ClusterActor, ClusterCommand};
 use tokio::sync::mpsc::Sender;
 
 use super::stream_manager::interface::TStream;
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PeerAddr(pub String);
-pub enum Connected<T: TStream> {
-    Replica {
-        peer_stream: T,
-        replication_stream: T,
-    },
-    ClusterMemeber {
-        peer_stream: T,
-    },
-}
-
-pub enum ClusterCommand<T: TStream> {
-    AddPeer(PeerAddr, Connected<T>),
-    RemovePeer(PeerAddr),
-    GetPeer(PeerAddr),
-}
 
 pub struct ClusterManager<T: TStream>(Sender<ClusterCommand<T>>);
 

--- a/src/services/config/command.rs
+++ b/src/services/config/command.rs
@@ -27,7 +27,6 @@ pub enum ConfigResource {
     DbFileName,
     FilePath,
     ReplicationInfo,
-    Peers,
 }
 
 pub enum ConfigResponse {
@@ -35,7 +34,6 @@ pub enum ConfigResponse {
     DbFileName(String),
     FilePath(String),
     ReplicationInfo(Vec<String>),
-    Peers(Vec<String>),
 }
 
 pub enum ConfigCommand {

--- a/src/services/config/config_actor.rs
+++ b/src/services/config/config_actor.rs
@@ -11,8 +11,6 @@ pub struct Config {
     pub(crate) dir: &'static str,
     pub dbfilename: &'static str,
     pub replication: Replication,
-    // TODO further implementation
-    pub peers: Vec<String>,
 }
 
 impl Config {
@@ -35,9 +33,6 @@ impl Config {
                     ConfigResource::ReplicationInfo => {
                         let _ = query
                             .respond_with(ConfigResponse::ReplicationInfo(self.replication.info()));
-                    }
-                    ConfigResource::Peers => {
-                        let _ = query.respond_with(ConfigResponse::Peers(self.peers.clone()));
                     }
                 },
                 ConfigMessage::Command(config_command) => match config_command {
@@ -101,7 +96,6 @@ impl Default for Config {
             dir: Box::leak(dir.into_boxed_str()),
             dbfilename: Box::leak(dbfilename.into_boxed_str()),
             replication: Replication::new(replicaof),
-            peers: vec![],
         }
     }
 }

--- a/src/services/config/config_manager.rs
+++ b/src/services/config/config_manager.rs
@@ -118,13 +118,4 @@ impl ConfigManager {
         self.send(ConfigMessage::Command(command)).await?;
         Ok(())
     }
-
-    pub(crate) async fn get_peers(&self) -> anyhow::Result<Vec<String>> {
-        let rx = self.route_query(ConfigResource::Peers).await?;
-        let ConfigResponse::Peers(peers) = rx.await? else {
-            return Err(anyhow::anyhow!("Failed to get peers"));
-        };
-
-        Ok(peers)
-    }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod cluster;
 pub mod config;
 pub mod interfaces;
 pub mod statefuls;

--- a/src/services/stream_manager/interface.rs
+++ b/src/services/stream_manager/interface.rs
@@ -1,13 +1,6 @@
 use bytes::BytesMut;
 
-use super::{
-    client_request_controllers::{
-        arguments::ClientRequestArguments, client_request::ClientRequest,
-    },
-    error::IoError,
-    query_io::QueryIO,
-    PeerAddr,
-};
+use super::{error::IoError, query_io::QueryIO, PeerAddr};
 
 pub trait TStream: TGetPeerIp + Send + Sync + 'static {
     // TODO deprecated
@@ -54,27 +47,8 @@ pub trait TCancellationWatcher: Send {
     fn watch(&mut self) -> bool;
 }
 
-pub trait TStreamListener<T>: Sync + Send + 'static
-where
-    T: TStream + TExtractQuery<ClientRequest, ClientRequestArguments>,
-{
-    fn listen(
-        &self,
-    ) -> impl std::future::Future<Output = std::result::Result<(T, std::net::SocketAddr), IoError>> + Send;
-}
-
 pub trait TGetPeerIp {
     fn get_peer_ip(&self) -> Result<String, IoError>;
-}
-
-pub trait TStreamListenerFactory<T>: Sync + Send + 'static
-where
-    T: TStream + TExtractQuery<ClientRequest, ClientRequestArguments>,
-{
-    fn create_listner(
-        &self,
-        bind_addr: String,
-    ) -> impl std::future::Future<Output = impl TStreamListener<T>> + Send;
 }
 
 pub trait TConnectStreamFactory<T>: Sync + Send + Copy + 'static

--- a/src/services/stream_manager/interface.rs
+++ b/src/services/stream_manager/interface.rs
@@ -42,28 +42,35 @@ pub trait TCancellationWatcher: Send {
     fn watch(&mut self) -> bool;
 }
 
-pub trait TStreamListener: Sync + Send + 'static {
+pub trait TStreamListener<T>: Sync + Send + 'static
+where
+    T: TStream,
+{
     fn listen(
         &self,
-    ) -> impl std::future::Future<
-        Output = std::result::Result<(impl TStream, std::net::SocketAddr), IoError>,
-    > + Send;
+    ) -> impl std::future::Future<Output = std::result::Result<(T, std::net::SocketAddr), IoError>> + Send;
 }
 
 pub trait TGetPeerIp {
     fn get_peer_ip(&self) -> Result<String, IoError>;
 }
 
-pub trait TStreamListenerFactory: Sync + Send + 'static {
+pub trait TStreamListenerFactory<T>: Sync + Send + 'static
+where
+    T: TStream,
+{
     fn create_listner(
         &self,
         bind_addr: String,
-    ) -> impl std::future::Future<Output = impl TStreamListener> + Send;
+    ) -> impl std::future::Future<Output = impl TStreamListener<T>> + Send;
 }
 
-pub trait TConnectStreamFactory: Sync + Send + Copy + 'static {
+pub trait TConnectStreamFactory<T>: Sync + Send + Copy + 'static
+where
+    T: TStream,
+{
     fn connect(
         &self,
         addr: PeerAddr,
-    ) -> impl std::future::Future<Output = Result<impl TStream, IoError>> + Send;
+    ) -> impl std::future::Future<Output = Result<T, IoError>> + Send;
 }

--- a/src/services/stream_manager/mod.rs
+++ b/src/services/stream_manager/mod.rs
@@ -23,6 +23,8 @@ use replication_request_controllers::{
 };
 use tokio::{task::yield_now, time::interval};
 
+use super::cluster::PeerAddr;
+
 /// Controller is a struct that will be used to read and write values to the client.
 pub struct StreamManager<T, U>
 where
@@ -102,8 +104,6 @@ where
     }
 }
 
-#[derive(Debug)]
-pub struct PeerAddr(pub String);
 impl<T> StreamManager<T, &'static ReplicationRequestController>
 where
     T: TStream,

--- a/src/services/stream_manager/mod.rs
+++ b/src/services/stream_manager/mod.rs
@@ -238,7 +238,7 @@ where
     // - Let the requesting peer know the other peers so they can connect
     pub(crate) async fn handle_peer_stream(
         mut self,
-        connect_stream_factory: impl TConnectStreamFactory,
+        connect_stream_factory: impl TConnectStreamFactory<T>,
     ) -> anyhow::Result<()> {
         let peer_addr = self.establish_threeway_handshake().await.unwrap();
 
@@ -262,7 +262,7 @@ where
 
     async fn schedule_heartbeat(
         &mut self,
-        connect_stream_factory: impl TConnectStreamFactory,
+        connect_stream_factory: impl TConnectStreamFactory<T>,
         peer_addr: PeerAddr,
     ) -> anyhow::Result<()> {
         // 1000 mills just because that's default for Redis.

--- a/src/services/stream_manager/mod.rs
+++ b/src/services/stream_manager/mod.rs
@@ -23,7 +23,7 @@ use replication_request_controllers::{
 };
 use tokio::{task::yield_now, time::interval};
 
-use super::cluster::PeerAddr;
+use super::cluster::actor::PeerAddr;
 
 /// Controller is a struct that will be used to read and write values to the client.
 pub struct StreamManager<T, U>

--- a/src/services/stream_manager/replication_request_controllers/mod.rs
+++ b/src/services/stream_manager/replication_request_controllers/mod.rs
@@ -1,7 +1,7 @@
 use arguments::PeerRequestArguments;
 use replication_request::ReplicationRequest;
 
-use crate::services::config::{config_manager::ConfigManager, ConfigCommand};
+use crate::services::config::config_manager::ConfigManager;
 
 use super::query_io::QueryIO;
 

--- a/src/services/stream_manager/replication_request_controllers/mod.rs
+++ b/src/services/stream_manager/replication_request_controllers/mod.rs
@@ -1,28 +1,2 @@
-use arguments::PeerRequestArguments;
-use replication_request::ReplicationRequest;
-
-use crate::services::config::config_manager::ConfigManager;
-
-use super::query_io::QueryIO;
-
 pub mod arguments;
 pub mod replication_request;
-
-pub struct ReplicationRequestController {
-    pub(crate) config_manager: ConfigManager,
-}
-
-impl ReplicationRequestController {
-    pub fn new(config_manager: ConfigManager) -> Self {
-        Self { config_manager }
-    }
-    pub async fn handle(
-        &self,
-        request: ReplicationRequest,
-        _args: PeerRequestArguments,
-    ) -> anyhow::Result<QueryIO> {
-        // handle replication request
-        let response = match request {};
-        Ok(response)
-    }
-}

--- a/tests/test_cancellation_token.rs
+++ b/tests/test_cancellation_token.rs
@@ -4,8 +4,11 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 mod common;
 use common::{init_config_manager_with_free_port, start_test_server, TestStreamHandler};
-use redis_starter_rust::services::stream_manager::interface::{
-    TCancellationNotifier, TCancellationTokenFactory, TCancellationWatcher,
+use redis_starter_rust::services::{
+    cluster::actor::ClusterActor,
+    stream_manager::interface::{
+        TCancellationNotifier, TCancellationTokenFactory, TCancellationWatcher,
+    },
 };
 use tokio::net::TcpStream;
 
@@ -13,8 +16,8 @@ use tokio::net::TcpStream;
 async fn test_cancellation_token() {
     // GIVEN
     let config = init_config_manager_with_free_port().await;
-
-    let _ = start_test_server(TestCancellationTokenFactory, config.clone()).await;
+    let cluster_actor = ClusterActor::new();
+    let _ = start_test_server(TestCancellationTokenFactory, config.clone(), cluster_actor).await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_config_get_dir.rs
+++ b/tests/test_config_get_dir.rs
@@ -7,7 +7,9 @@ mod common;
 use common::{init_config_manager_with_free_port, start_test_server, TestStreamHandler};
 
 use crate::common::{array, config_command};
-use redis_starter_rust::adapters::cancellation_token::CancellationTokenFactory;
+use redis_starter_rust::{
+    adapters::cancellation_token::CancellationTokenFactory, services::cluster::actor::ClusterActor,
+};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -15,8 +17,8 @@ async fn test_config_get_dir() {
     // GIVEN
     //TODO test config should be dynamically configured
     let config = init_config_manager_with_free_port().await;
-
-    let _ = start_test_server(CancellationTokenFactory, config.clone()).await;
+    let cluster_actor = ClusterActor::new();
+    let _ = start_test_server(CancellationTokenFactory, config.clone(), cluster_actor).await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
 

--- a/tests/test_handshake.rs
+++ b/tests/test_handshake.rs
@@ -11,7 +11,10 @@
 use common::{find_free_port_in_range, start_test_server, TestStreamHandler};
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
-    services::config::{config_actor::Config, config_manager::ConfigManager},
+    services::{
+        cluster::actor::ClusterActor,
+        config::{config_actor::Config, config_manager::ConfigManager},
+    },
 };
 use tokio::net::TcpStream;
 mod common;
@@ -25,7 +28,9 @@ async fn test_threeway_handshake() {
     // ! `peer_bind_addr` is bind_addr dedicated for peer connections
     manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
     let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager).await;
+    let cluster_actor: ClusterActor = ClusterActor::new();
+
+    let _ = start_test_server(CancellationTokenFactory, manager, cluster_actor).await;
     let mut client_stream = TcpStream::connect(master_cluster_bind_addr).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();
 

--- a/tests/test_heartbeat.rs
+++ b/tests/test_heartbeat.rs
@@ -10,6 +10,7 @@ use common::{find_free_port_in_range, start_test_server, threeway_handshake_help
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
     services::{
+        cluster::actor::ClusterActor,
         config::{config_actor::Config, config_manager::ConfigManager},
         stream_manager::interface::TStream,
     },
@@ -42,7 +43,7 @@ async fn test_heartbeat() {
     let mut manager = ConfigManager::new(config);
     manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
     let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager).await;
+    let _ = start_test_server(CancellationTokenFactory, manager, ClusterActor::new()).await;
 
     // run the slave stream on a random port
     let slave_port = 6778;
@@ -66,7 +67,7 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
     let mut manager = ConfigManager::new(config);
     manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
     let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager).await;
+    let _ = start_test_server(CancellationTokenFactory, manager, ClusterActor::new()).await;
 
     // run the slave stream on a random port
     let repl_port1 = 6779;

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -1,6 +1,9 @@
 mod common;
 
-use common::{find_free_port_in_range, start_test_server, threeway_handshake_helper};
+use common::{
+    create_cluster_actor_with_peers, find_free_port_in_range, start_test_server,
+    threeway_handshake_helper,
+};
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
     services::{
@@ -29,18 +32,24 @@ async fn replica_server_helper(replica_port: u16) {
 }
 
 #[tokio::test]
+#[ignore = "Not yet ready"]
 async fn test_heartbeat_sent_to_multiple_replicas() {
     // GIVEN
     // run fake replica server on specific port
     let fake_repl_port = 6781;
     let fake_repl_address = "localhost:".to_string() + &fake_repl_port.to_string();
     // create master server with fake replica address as peers
-    let mut config = Config::default();
-    config.peers = vec![fake_repl_address.to_string()];
+    let config = Config::default();
     let mut manager = ConfigManager::new(config);
+
     manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
     let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager.clone()).await;
+    let _ = start_test_server(
+        CancellationTokenFactory,
+        manager.clone(),
+        create_cluster_actor_with_peers(vec![fake_repl_address.clone()]),
+    )
+    .await;
     // run the fake replica server in advance
     let handler = tokio::spawn(replica_server_helper(fake_repl_port + 10000));
 
@@ -52,7 +61,12 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
         config.replication.master_host = Some("localhost".to_string());
         let mut manager = ConfigManager::new(config);
         manager.port = target_repl;
-        let _ = start_test_server(CancellationTokenFactory, manager).await;
+        let _ = start_test_server(
+            CancellationTokenFactory,
+            manager,
+            create_cluster_actor_with_peers(vec![fake_repl_address.clone()]),
+        )
+        .await;
     }
 
     // WHEN target replica connects to master

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -55,7 +55,6 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
         let _ = start_test_server(CancellationTokenFactory, manager).await;
     }
 
-
     // WHEN target replica connects to master
     let mut repl1_connecting_to_master = TcpStream::connect(master_cluster_bind_addr.clone())
         .await
@@ -64,5 +63,8 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
 
     // THEN target replica sends 5 PING messages to fake replica
     // TODO: remove timeout when we implement the actual cluster heartbeat
-    timeout(std::time::Duration::from_secs(10), handler).await.unwrap().unwrap();
+    timeout(std::time::Duration::from_secs(10), handler)
+        .await
+        .unwrap()
+        .unwrap();
 }

--- a/tests/test_keys.rs
+++ b/tests/test_keys.rs
@@ -2,7 +2,9 @@ mod common;
 use crate::common::{keys_command, ok_response, set_command};
 use common::{init_config_manager_with_free_port, start_test_server, TestStreamHandler};
 
-use redis_starter_rust::adapters::cancellation_token::CancellationTokenFactory;
+use redis_starter_rust::{
+    adapters::cancellation_token::CancellationTokenFactory, services::cluster::actor::ClusterActor,
+};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -10,7 +12,12 @@ async fn test_keys() {
     // GIVEN
     let config = init_config_manager_with_free_port().await;
 
-    let _ = start_test_server(CancellationTokenFactory, config.clone()).await;
+    let _ = start_test_server(
+        CancellationTokenFactory,
+        config.clone(),
+        ClusterActor::new(),
+    )
+    .await;
 
     let mut stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = stream.split().into();

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -7,7 +7,9 @@ mod common;
 use crate::common::{bulk_string, info_command};
 use common::{init_config_manager_with_free_port, start_test_server, TestStreamHandler};
 
-use redis_starter_rust::adapters::cancellation_token::CancellationTokenFactory;
+use redis_starter_rust::{
+    adapters::cancellation_token::CancellationTokenFactory, services::cluster::actor::ClusterActor,
+};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -16,7 +18,12 @@ async fn test_replication_info() {
     //TODO test config should be dynamically configured
     let config = init_config_manager_with_free_port().await;
 
-    start_test_server(CancellationTokenFactory, config.clone()).await;
+    start_test_server(
+        CancellationTokenFactory,
+        config.clone(),
+        ClusterActor::new(),
+    )
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_save_read_dump.rs
+++ b/tests/test_save_read_dump.rs
@@ -11,7 +11,10 @@ use crate::common::{
 use common::{init_config_manager_with_free_port, TestStreamHandler};
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
-    services::config::{ConfigCommand, ConfigMessage},
+    services::{
+        cluster::actor::ClusterActor,
+        config::{ConfigCommand, ConfigMessage},
+    },
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
@@ -36,7 +39,12 @@ async fn test_save_read_dump() {
         .await
         .unwrap();
 
-    let _ = start_test_server(CancellationTokenFactory, config.clone()).await;
+    let _ = start_test_server(
+        CancellationTokenFactory,
+        config.clone(),
+        ClusterActor::new(),
+    )
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();
@@ -62,7 +70,12 @@ async fn test_save_read_dump() {
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
     // start another instance
-    let _ = start_test_server(CancellationTokenFactory, config.clone()).await;
+    let _ = start_test_server(
+        CancellationTokenFactory,
+        config.clone(),
+        ClusterActor::new(),
+    )
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();

--- a/tests/test_set_get.rs
+++ b/tests/test_set_get.rs
@@ -8,7 +8,9 @@ use crate::common::{
 };
 use common::{init_config_manager_with_free_port, start_test_server, TestStreamHandler};
 
-use redis_starter_rust::adapters::cancellation_token::CancellationTokenFactory;
+use redis_starter_rust::{
+    adapters::cancellation_token::CancellationTokenFactory, services::cluster::actor::ClusterActor,
+};
 use tokio::net::TcpStream;
 
 #[tokio::test]
@@ -16,7 +18,12 @@ async fn test_set_get() {
     // GIVEN
     let config = init_config_manager_with_free_port().await;
 
-    let _ = start_test_server(CancellationTokenFactory, config.clone()).await;
+    let _ = start_test_server(
+        CancellationTokenFactory,
+        config.clone(),
+        ClusterActor::new(),
+    )
+    .await;
 
     let mut client_stream = TcpStream::connect(config.bind_addr()).await.unwrap();
     let mut h: TestStreamHandler = client_stream.split().into();


### PR DESCRIPTION
#112 

#116 

#114 

Reason for the change:

The system has a significant dependency on the Tokio runtime, which I initially considered a volatile and potentially risky dependency. However, this dependency cascades throughout the codebase—from main to startup and down to each dispatcher—introducing unnecessary generic complexity.

Additionally, as the `ClusteringManager` is expected to manage streams, this generic coupling hinders the domain from remaining implementation-specific.

I could've just used dynamic dispatch but it's only adding up the cost - which we shouldn't without valid reasons. 


