### PR TITLE
fix: client port assumption

### DIFF
--- a/src/adapters/io/tokio_stream.rs
+++ b/src/adapters/io/tokio_stream.rs
@@ -6,18 +6,15 @@ use crate::services::stream_manager::request_controller::replica::replication_re
 use crate::services::stream_manager::request_controller::replica::{
     arguments::PeerRequestArguments, replication_request::HandShakeRequest,
 };
-use crate::services::{
-    cluster::actor::PeerAddr,
-    stream_manager::{
-        error::IoError,
-        interface::{TExtractQuery, TGetPeerIp, TRead, TStream},
-        query_io::{parse, QueryIO},
-    },
+use crate::services::stream_manager::{
+    error::IoError,
+    interface::{TExtractQuery, TGetPeerIp, TRead, TStream},
+    query_io::{parse, QueryIO},
 };
 use anyhow::Context;
 use bytes::BytesMut;
 use std::io::ErrorKind;
-use tokio::net::tcp::{OwnedWriteHalf, WriteHalf};
+use tokio::net::tcp::OwnedWriteHalf;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,12 @@ use anyhow::Result;
 use services::cluster::actor::ClusterActor;
 use services::cluster::manager::ClusterManager;
 use services::config::manager::ConfigManager;
-use services::stream_manager::request_controller::client::ClientRequestController;
-
 use services::statefuls::cache::manager::CacheManager;
 use services::statefuls::cache::ttl::manager::TtlSchedulerInbox;
 use services::statefuls::persist::actor::PersistActor;
-
 use services::stream_manager::error::IoError;
 use services::stream_manager::interface::TCancellationTokenFactory;
+use services::stream_manager::request_controller::client::ClientRequestController;
 use services::stream_manager::StreamManager;
 
 // * StartUp Facade that manages invokes subsystems

--- a/src/services/cluster/actor.rs
+++ b/src/services/cluster/actor.rs
@@ -141,8 +141,6 @@ impl ClusterWriteActor {
                         // do something
                     }
                     ClusterWriteCommand::Ping => {
-                        println!("ping received");
-
                         actor.heartbeat().await;
                     }
                     ClusterWriteCommand::Join {

--- a/src/services/cluster/actor.rs
+++ b/src/services/cluster/actor.rs
@@ -10,6 +10,7 @@ use tokio::time::interval;
 use tokio::{net::TcpStream, sync::mpsc::Receiver};
 
 pub struct ClusterActor {
+    // TODO change PeerAddr to PeerIdentifier
     pub peers: HashSet<PeerAddr>,
 }
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
@@ -95,7 +96,7 @@ async fn run_cluster_read_actor(mut sr: Receiver<ClusterReadCommand>) {
     while let Some(command) = sr.recv().await {
         match command {
             ClusterReadCommand::Ping => {
-                // do something
+                // do something - failure detection!
             }
             ClusterReadCommand::Join { addr, buffer } => {
                 members.entry(addr).or_insert(buffer);
@@ -140,6 +141,8 @@ impl ClusterWriteActor {
                         // do something
                     }
                     ClusterWriteCommand::Ping => {
+                        println!("ping received");
+
                         actor.heartbeat().await;
                     }
                     ClusterWriteCommand::Join {

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -75,7 +75,7 @@ impl ClusterManager {
         yield_now().await;
 
         Ok((
-            PeerAddr(format!("{}:{}", stream.get_peer_ip()?, port + 10000)),
+            PeerAddr(format!("{}:{}", stream.get_peer_ip()?, port)),
             _repl_id == "?", // if repl_id is '?' or of mine, it's slave, otherwise it's a peer.
         ))
     }
@@ -95,7 +95,7 @@ impl ClusterManager {
     async fn handle_replconf_listening_port(
         &self,
         stream: &mut (impl TExtractQuery<HandShakeRequest, PeerRequestArguments> + TStream),
-    ) -> anyhow::Result<i16> {
+    ) -> anyhow::Result<u16> {
         let (HandShakeRequest::ReplConf, query_args) = stream.extract_query().await? else {
             return Err(anyhow::anyhow!("ReplConf not given during handshake"));
         };
@@ -109,7 +109,7 @@ impl ClusterManager {
             .write(QueryIO::SimpleString("OK".to_string()))
             .await?;
 
-        Ok(port.parse::<i16>()?)
+        Ok(port.parse::<u16>()?)
     }
 
     async fn handle_replconf_capa(

--- a/src/services/config/manager.rs
+++ b/src/services/config/manager.rs
@@ -2,10 +2,10 @@ use std::time::SystemTime;
 
 use crate::env_var;
 
+use super::actor::ConfigActor;
 use super::command::ConfigCommand;
 use super::command::ConfigMessage;
 use super::command::ConfigQuery;
-use super::actor::ConfigActor;
 use super::ConfigResource;
 use super::ConfigResponse;
 

--- a/src/services/stream_manager/interface.rs
+++ b/src/services/stream_manager/interface.rs
@@ -1,6 +1,5 @@
+use super::{error::IoError, query_io::QueryIO};
 use bytes::BytesMut;
-
-use super::{error::IoError, query_io::QueryIO, PeerAddr};
 
 pub trait TStream: TGetPeerIp + Send + Sync + 'static {
     // TODO deprecated

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use redis_starter_rust::services::cluster::actor::{ClusterActor, PeerAddr};
+use redis_starter_rust::services::cluster::actor::{ClusterActor, ClusterWriteConnected, PeerAddr};
 use redis_starter_rust::services::config::actor::ConfigActor;
 use redis_starter_rust::services::config::manager::ConfigManager;
 use redis_starter_rust::services::stream_manager::interface::{TCancellationTokenFactory, TStream};

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use redis_starter_rust::services::cluster::actor::{ClusterActor, ClusterWriteConnected, PeerAddr};
+use redis_starter_rust::services::cluster::actor::{ClusterActor, PeerAddr};
 use redis_starter_rust::services::config::actor::ConfigActor;
 use redis_starter_rust::services::config::manager::ConfigManager;
 use redis_starter_rust::services::stream_manager::interface::{TCancellationTokenFactory, TStream};

--- a/tests/test_disseminate_peers.rs
+++ b/tests/test_disseminate_peers.rs
@@ -1,8 +1,8 @@
 /// After three-way handshake, client will receive peers from the master server
 mod common;
 use common::{
-    create_cluster_actor_with_peers, find_free_port_in_range, start_test_server,
-    threeway_handshake_helper,
+    create_cluster_actor_with_peers, fake_threeway_handshake_helper, find_free_port_in_range,
+    start_test_server,
 };
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
@@ -34,8 +34,7 @@ async fn test_disseminate_peers() {
 
     let mut client_stream = TcpStream::connect(master_cluster_bind_addr).await.unwrap();
 
-    let client_fake_port = 6889;
-    let message = threeway_handshake_helper(&mut client_stream, client_fake_port).await;
+    let message = fake_threeway_handshake_helper(&mut client_stream).await;
 
     let expected = format!("+PEERS {}\r\n", peer_address_to_test);
     if let Some(combined) = message {

--- a/tests/test_heartbeat.rs
+++ b/tests/test_heartbeat.rs
@@ -20,20 +20,17 @@ use redis_starter_rust::{
 use tokio::{net::TcpStream, time::timeout};
 
 // The following simulate the replica server by creating a TcpStream that will be connected by the master server
-async fn replica_server_helper(replica_port: u16) {
-    let slave_cluster_bind_addr = format!("localhost:{}", replica_port + 10000); // note we add 10000 this is convention
-    let listener = tokio::net::TcpListener::bind(&slave_cluster_bind_addr)
-        .await
-        .unwrap();
-    while let Ok((mut stream, _)) = listener.accept().await {
-        let mut count = 0;
-        while count < 5 {
-            let values = stream.read_value().await.unwrap();
-            // TODO PING may not be used. It is just a placeholder
-            assert_eq!(values.serialize(), "+PING\r\n");
-            count += 1;
+async fn receive_server_ping_from_replica_stream(mut stream_handler: TcpStream) {
+    let mut count = 0;
+    while let Ok(values) = stream_handler.read_value().await {
+        if count == 5 {
+            break;
         }
-        break;
+
+        println!("{:?}", values);
+        // TODO PING may not be used. It is just a placeholder
+        assert_eq!(values.serialize(), "+PING\r\n");
+        count += 1;
     }
 }
 
@@ -50,49 +47,50 @@ async fn test_heartbeat() {
     // run the slave stream on a random port
     let slave_port = 6778;
 
-    // run the client bind stream on a random port so it can later get connection request from server
-    let handler = tokio::spawn(replica_server_helper(slave_port));
-
     // WHEN making three-way handshake, server will connect to the client's server which is in this case
     let mut client_stream = TcpStream::connect(master_cluster_bind_addr).await.unwrap();
     threeway_handshake_helper(&mut client_stream, slave_port).await;
 
+    // run the client bind stream on a random port so it can later get connection request from server
+    let handler: tokio::task::JoinHandle<()> =
+        tokio::spawn(receive_server_ping_from_replica_stream(client_stream));
+
     //WHEN we await on handler, it will receive 5 PING messages
-    timeout(Duration::from_secs(5), handler)
+    timeout(Duration::from_secs(6), handler)
         .await
         .unwrap()
         .unwrap();
 }
 
-#[tokio::test]
-async fn test_heartbeat_sent_to_multiple_replicas() {
-    // GIVEN
-    // run the random server on a random port
-    let config = ConfigActor::default();
-    let mut manager = ConfigManager::new(config);
-    manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
-    let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager, ClusterActor::new()).await;
+// #[tokio::test]
+// async fn test_heartbeat_sent_to_multiple_replicas() {
+//     // GIVEN
+//     // run the random server on a random port
+//     let config = ConfigActor::default();
+//     let mut manager = ConfigManager::new(config);
+//     manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
+//     let master_cluster_bind_addr = manager.peer_bind_addr();
+//     let _ = start_test_server(CancellationTokenFactory, manager, ClusterActor::new()).await;
 
-    // run the slave stream on a random port
-    let repl_port1 = 6779;
-    let repl_port2 = 6780;
+//     // run the slave stream on a random port
+//     let repl_port1 = 6779;
+//     let repl_port2 = 6780;
 
-    // run the client bind stream on a random port so it can later get connection request from server
-    let repl1_handler = tokio::spawn(replica_server_helper(repl_port1));
-    let repl2_handler = tokio::spawn(replica_server_helper(repl_port2));
+//     // run the client bind stream on a random port so it can later get connection request from server
+//     let repl1_handler = tokio::spawn(replica_server_helper(repl_port1));
+//     let repl2_handler = tokio::spawn(replica_server_helper(repl_port2));
 
-    // WHEN making three-way handshake, server will connect to the client's server which is in this case
-    let mut repl1_connecting_to_master = TcpStream::connect(master_cluster_bind_addr.clone())
-        .await
-        .unwrap();
-    threeway_handshake_helper(&mut repl1_connecting_to_master, repl_port1).await;
+//     // WHEN making three-way handshake, server will connect to the client's server which is in this case
+//     let mut repl1_connecting_to_master = TcpStream::connect(master_cluster_bind_addr.clone())
+//         .await
+//         .unwrap();
+//     threeway_handshake_helper(&mut repl1_connecting_to_master, repl_port1).await;
 
-    let mut repl2_connecting_to_master =
-        TcpStream::connect(master_cluster_bind_addr).await.unwrap();
-    threeway_handshake_helper(&mut repl2_connecting_to_master, repl_port2).await;
+//     let mut repl2_connecting_to_master =
+//         TcpStream::connect(master_cluster_bind_addr).await.unwrap();
+//     threeway_handshake_helper(&mut repl2_connecting_to_master, repl_port2).await;
 
-    //WHEN we await on handler, it will receive 5 PING messages
-    repl1_handler.await.unwrap();
-    repl2_handler.await.unwrap();
-}
+//     //WHEN we await on handler, it will receive 5 PING messages
+//     repl1_handler.await.unwrap();
+//     repl2_handler.await.unwrap();
+// }

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -1,8 +1,7 @@
 mod common;
-
 use common::{
-    create_cluster_actor_with_peers, find_free_port_in_range, start_test_server,
-    threeway_handshake_helper,
+    create_cluster_actor_with_peers, fake_threeway_handshake_helper, find_free_port_in_range,
+    start_test_server,
 };
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
@@ -14,8 +13,9 @@ use redis_starter_rust::{
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 
+// TODO remove the following
 async fn replica_server_helper(replica_port: u16) {
-    let slave_cluster_bind_addr = format!("localhost:{}", replica_port + 10000); // note we add 10000 this is convention
+    let slave_cluster_bind_addr = format!("localhost:{}", replica_port); // note we add 10000 this is convention
     let listener = tokio::net::TcpListener::bind(&slave_cluster_bind_addr)
         .await
         .unwrap();
@@ -71,7 +71,7 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
         let mut repl1_connecting_to_master = TcpStream::connect(master_cluster_bind_addr.clone())
             .await
             .unwrap();
-        threeway_handshake_helper(&mut repl1_connecting_to_master, connecting_replica_port).await;
+        fake_threeway_handshake_helper(&mut repl1_connecting_to_master).await;
     }
 
     // THEN newly connected replica sends PINGs to fake replica


### PR DESCRIPTION
Client used in test was implemented with the wrong assumption that client port can be static - which is simply wrong. 

Everytime client makes connection, dynamic port is allocated . 

Identifying client based on its IP and port is not, therefore, a viable option. 
