### PR TITLE
refactor: simplify route query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,12 +83,12 @@ where
         ));
 
         // depending on master-slave state, we may need to start accepting client connections
-        let repl_info_receiver = self
+        let repl = self
             .config_manager
             .route_query(ConfigResource::ReplicationInfo)
             .await?;
 
-        match repl_info_receiver.await? {
+        match repl {
             ConfigResponse::ReplicationInfo(repl_info) => {
                 if IS_MASTER_MODE.load(std::sync::atomic::Ordering::Relaxed) {
                     self.start_accepting_client_connections(

--- a/src/services/stream_manager/request_controller/client/mod.rs
+++ b/src/services/stream_manager/request_controller/client/mod.rs
@@ -77,9 +77,9 @@ impl ClientRequestController {
             // modify we have to add a new command
             ClientRequest::Config => {
                 let cmd = args.take_config_args()?;
-                let rx = self.config_manager.route_get(cmd).await?;
+                let res = self.config_manager.route_get(cmd).await?;
 
-                match rx.await? {
+                match res {
                     ConfigResponse::Dir(value) => QueryIO::Array(vec![
                         QueryIO::BulkString("dir".into()),
                         QueryIO::BulkString(value),


### PR DESCRIPTION
instead of returning `oneshot::Receiver<_>`, it extract the response and return. 