### PR TITLE
feat: cluster listening actor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
     }
 
     async fn start_mode_specific_connection_handling(&mut self) -> anyhow::Result<()> {
-        let mut is_master_mode: bool = self.config_manager.cluster_mode();
+        let mut is_master_mode = self.config_manager.cluster_mode();
         loop {
             let (stop_sentinel_tx, stop_sentinel_recv) = tokio::sync::oneshot::channel::<()>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,7 @@ where
         // will live for the entire duration of the program.
         let cache_manager: &'static CacheManager = Box::leak(cache_manager.into());
         let client_request_controller: &'static ClientManager = Box::leak(
-            ClientManager::new(config_manager.clone(), cache_manager, ttl_inbox.clone())
-                .into(),
+            ClientManager::new(config_manager.clone(), cache_manager, ttl_inbox.clone()).into(),
         );
 
         StartUpFacade {
@@ -105,7 +104,7 @@ where
     }
 
     async fn start_mode_specific_connection_handling(&mut self) -> anyhow::Result<()> {
-        let mut is_master_mode = self.config_manager.cluster_mode();
+        let mut is_master_mode: bool = self.config_manager.cluster_mode();
         loop {
             let (stop_sentinel_tx, stop_sentinel_recv) = tokio::sync::oneshot::channel::<()>();
 

--- a/src/services/client/manager.rs
+++ b/src/services/client/manager.rs
@@ -55,7 +55,7 @@ impl ClientManager {
                     self.config_manager.get_filepath().await?,
                     self.cache_manager.inboxes.len(),
                 )
-                    .await?;
+                .await?;
 
                 self.cache_manager.route_save(outbox).await;
 

--- a/src/services/client/mod.rs
+++ b/src/services/client/mod.rs
@@ -1,5 +1,4 @@
 pub mod arguments;
+pub mod manager;
 pub mod request;
 pub mod stream;
-pub mod manager;
-

--- a/src/services/cluster/actor.rs
+++ b/src/services/cluster/actor.rs
@@ -3,7 +3,7 @@ use crate::make_smart_pointer;
 use crate::services::cluster::command::{ClusterCommand, PeerKind};
 use crate::services::interface::{TRead, TWrite};
 use crate::services::query_io::QueryIO;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::select;
 use tokio::sync::mpsc::Receiver;
@@ -13,9 +13,7 @@ use tokio::task::JoinHandle;
 #[derive(Debug, Default)]
 pub struct ClusterActor {
     // TODO change PeerAddr to PeerIdentifier
-    pub peers: HashSet<PeerAddr>,
-    write_members: BTreeMap<PeerAddr, ClusterWriteConnected>,
-    read_members: BTreeMap<PeerAddr, PeerListenerHandler>,
+    members: BTreeMap<PeerAddr, (ClusterWriteConnected, PeerListenerHandler)>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
@@ -24,17 +22,17 @@ make_smart_pointer!(PeerAddr, String);
 
 impl ClusterActor {
     async fn heartbeat(&mut self) {
-        for connected in self.write_members.values_mut() {
+        for (connected, _) in self.members.values_mut() {
             let _ = connected.ping().await;
         }
     }
 
     async fn remove_peer(&mut self, peer_addr: PeerAddr) {
-        if let Some(connected) = self.read_members.remove(&peer_addr) {
+        if let Some((_, listener_handler)) = self.members.remove(&peer_addr) {
             // stop the runnin process and take the connection in case topology changes are made
-            let _read_connected = connected.kill().await;
+            let _read_connected = listener_handler.kill().await;
         }
-        self.write_members.remove(&peer_addr);
+        self.members.remove(&peer_addr);
     }
 
     pub async fn handle(
@@ -52,14 +50,10 @@ impl ClusterActor {
                     let listner_task_handler = tokio::spawn(listener.listen(kill_switch));
 
                     // composite
-                    self.read_members.insert(
-                        peer_addr.clone(),
+                    self.members.entry(peer_addr).or_insert((
+                        ClusterWriteConnected::new(w, peer_kind),
                         PeerListenerHandler(kill_trigger, listner_task_handler),
-                    );
-
-                    self.write_members
-                        .entry(peer_addr)
-                        .or_insert(ClusterWriteConnected::new(w, peer_kind));
+                    ));
                 }
                 ClusterCommand::RemovePeer(peer_addr) => {
                     self.remove_peer(peer_addr).await;
@@ -67,7 +61,7 @@ impl ClusterActor {
 
                 ClusterCommand::GetPeers(callback) => {
                     // send
-                    let _ = callback.send(self.peers.iter().cloned().collect());
+                    let _ = callback.send(self.members.keys().cloned().collect());
                 }
                 ClusterCommand::Write(write_cmd) => match write_cmd {
                     ClusterWriteCommand::Replicate { query: _ } => todo!(),

--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -1,19 +1,19 @@
-use super::command::ClusterWriteCommand;
+use super::command::{ClusterCommand, ClusterWriteCommand, PeerKind};
+use super::listening_actor::{ClusterReadConnected, PeerListenerHandler, PeerListeningActor};
 use crate::make_smart_pointer;
-use crate::services::cluster::command::{ClusterCommand, PeerKind};
-use crate::services::interface::{TRead, TWrite};
+
+use crate::services::interface::TWrite;
 use crate::services::query_io::QueryIO;
 use std::collections::BTreeMap;
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::tcp::OwnedWriteHalf;
 use tokio::net::TcpStream;
-use tokio::select;
+
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
-use tokio::task::JoinHandle;
 
 #[derive(Debug, Default)]
 pub struct ClusterActor {
-    // PeerAddr is cluster ip:cluster_port of peer
+    // PeerAddr is cluster ip:{cluster_port} of peer
     members: BTreeMap<PeerAddr, Peer>,
 }
 
@@ -111,12 +111,12 @@ impl Peer {
 
         // Listner requires cluster handler to send messages to the cluster actor and cluster actor instead needs kill trigger to stop the listener
         let (kill_trigger, kill_switch) = tokio::sync::oneshot::channel();
-        let listener = PeerListener { read_connected, cluster_handler };
+        let listener = PeerListeningActor { read_connected, cluster_handler };
         let listener_task_handler = tokio::spawn(listener.listen(kill_switch));
 
         Self {
             write_connected,
-            listener_handler: PeerListenerHandler(kill_trigger, listener_task_handler),
+            listener_handler: PeerListenerHandler::new(kill_trigger, listener_task_handler),
         }
     }
 }
@@ -126,66 +126,4 @@ pub enum ClusterWriteConnected {
     Replica { stream: OwnedWriteHalf },
     Peer { stream: OwnedWriteHalf },
     Master { stream: OwnedWriteHalf },
-}
-
-struct PeerListener {
-    read_connected: ClusterReadConnected,
-    cluster_handler: Sender<ClusterCommand>, // cluster_handler is used to send messages to the cluster actor
-}
-
-#[derive(Debug)]
-struct PeerListenerHandler(ListenerKillTrigger, JoinHandle<ClusterReadConnected>);
-impl PeerListenerHandler {
-    async fn kill(self) -> ClusterReadConnected {
-        let _ = self.0.send(());
-        self.1.await.unwrap()
-    }
-}
-
-type ListenerKillTrigger = tokio::sync::oneshot::Sender<()>;
-type ListenerKillSwitch = tokio::sync::oneshot::Receiver<()>;
-
-impl PeerListener {
-    // TODO only outline is done
-    async fn listen(mut self, rx: ListenerKillSwitch) -> ClusterReadConnected {
-        let connected = select! {
-            _ = async{
-                    match self.read_connected {
-                        ClusterReadConnected::Replica { ref mut stream } =>Self::listen_replica_stream( stream ).await,
-                        ClusterReadConnected::Peer { ref mut stream } =>Self::listen_peer_stream( stream ).await,
-                        ClusterReadConnected::Master { ref mut stream } => Self::listen_master_stream( stream ).await,
-                    };
-                } => {
-                    self.read_connected
-                },
-            _ = rx => {
-                // If the kill switch is triggered, return the connected stream so the caller can decide what to do with it
-                self.read_connected
-            }
-        };
-        connected
-    }
-
-    async fn listen_replica_stream(read_buf: &mut OwnedReadHalf) {
-        while let Ok(values) = read_buf.read_values().await {
-            let _ = values;
-        }
-    }
-    async fn listen_peer_stream(read_buf: &mut OwnedReadHalf) {
-        while let Ok(values) = read_buf.read_values().await {
-            let _ = values;
-        }
-    }
-    async fn listen_master_stream(read_buf: &mut OwnedReadHalf) {
-        while let Ok(values) = read_buf.read_values().await {
-            let _ = values;
-        }
-    }
-}
-
-#[derive(Debug)]
-enum ClusterReadConnected {
-    Replica { stream: OwnedReadHalf },
-    Peer { stream: OwnedReadHalf },
-    Master { stream: OwnedReadHalf },
 }

--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -1,5 +1,7 @@
-use crate::services::{cluster::actor::PeerAddr, query_io::QueryIO};
+use crate::services::query_io::QueryIO;
 use tokio::net::TcpStream;
+
+use super::actor::PeerAddr;
 
 pub enum ClusterCommand {
     AddPeer { peer_addr: PeerAddr, stream: TcpStream, peer_kind: PeerKind },

--- a/src/services/cluster/actors/listening_actor.rs
+++ b/src/services/cluster/actors/listening_actor.rs
@@ -1,0 +1,77 @@
+/// PeerListeningActor is responsible for listening to incoming messages from a peer.
+/// Message from a peer is one of events that can trigger a change in the cluster state.
+/// As it has to keep listening to incoming messages, it is implemented as an actor, run in the background.
+/// To take a control of the actor, PeerListenerHandler is used, which can kill the listening process and return the connected stream.
+use super::command::ClusterCommand;
+use crate::services::interface::TRead;
+use tokio::net::tcp::OwnedReadHalf;
+use tokio::select;
+use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+
+pub(crate) struct PeerListeningActor {
+    pub(super) read_connected: ClusterReadConnected,
+    pub(super) cluster_handler: Sender<ClusterCommand>, // cluster_handler is used to send messages to the cluster actor
+}
+
+#[derive(Debug)]
+pub(super) enum ClusterReadConnected {
+    Replica { stream: OwnedReadHalf },
+    Peer { stream: OwnedReadHalf },
+    Master { stream: OwnedReadHalf },
+}
+
+impl PeerListeningActor {
+    pub(super) async fn listen(mut self, rx: ReactorKillSwitch) -> ClusterReadConnected {
+        let connected = select! {
+            _ = async{
+                    match self.read_connected {
+                        ClusterReadConnected::Replica { ref mut stream } =>Self::listen_replica_stream( stream ).await,
+                        ClusterReadConnected::Peer { ref mut stream } =>Self::listen_peer_stream( stream ).await,
+                        ClusterReadConnected::Master { ref mut stream } => Self::listen_master_stream( stream ).await,
+                    };
+                } => {
+                    self.read_connected
+                },
+            _ = rx => {
+                // If the kill switch is triggered, return the connected stream so the caller can decide what to do with it
+                self.read_connected
+            }
+        };
+        connected
+    }
+
+    async fn listen_replica_stream(read_buf: &mut OwnedReadHalf) {
+        while let Ok(values) = read_buf.read_values().await {
+            let _ = values;
+        }
+    }
+    async fn listen_peer_stream(read_buf: &mut OwnedReadHalf) {
+        while let Ok(values) = read_buf.read_values().await {
+            let _ = values;
+        }
+    }
+    async fn listen_master_stream(read_buf: &mut OwnedReadHalf) {
+        while let Ok(values) = read_buf.read_values().await {
+            let _ = values;
+        }
+    }
+}
+
+pub(super) type ReactorKillTrigger = tokio::sync::oneshot::Sender<()>;
+pub(super) type ReactorKillSwitch = tokio::sync::oneshot::Receiver<()>;
+
+#[derive(Debug)]
+pub(super) struct PeerListenerHandler(ReactorKillTrigger, JoinHandle<ClusterReadConnected>);
+impl PeerListenerHandler {
+    pub(super) fn new(
+        kill_trigger: ReactorKillTrigger,
+        listener_task_handler: JoinHandle<ClusterReadConnected>,
+    ) -> Self {
+        Self(kill_trigger, listener_task_handler)
+    }
+    pub(super) async fn kill(self) -> ClusterReadConnected {
+        let _ = self.0.send(());
+        self.1.await.unwrap()
+    }
+}

--- a/src/services/cluster/actors/mod.rs
+++ b/src/services/cluster/actors/mod.rs
@@ -1,0 +1,3 @@
+pub(super) mod actor;
+pub mod command;
+mod listening_actor;

--- a/src/services/cluster/inbound/mod.rs
+++ b/src/services/cluster/inbound/mod.rs
@@ -1,3 +1,3 @@
-pub mod stream;
-pub mod request;
 pub mod arguments;
+pub mod request;
+pub mod stream;

--- a/src/services/cluster/inbound/request.rs
+++ b/src/services/cluster/inbound/request.rs
@@ -40,10 +40,10 @@ impl HandShakeRequest {
 
         match self.args.as_mut_slice() {
             [QueryIO::BulkString(key), QueryIO::BulkString(port), ..]
-            if key == "listening-port" =>
-                {
-                    Ok(port.parse::<u16>()?)
-                }
+                if key == "listening-port" =>
+            {
+                Ok(port.parse::<u16>()?)
+            }
             _ => Err(anyhow::anyhow!("Invalid listening-port arguments")),
         }
     }

--- a/src/services/cluster/inbound/stream.rs
+++ b/src/services/cluster/inbound/stream.rs
@@ -1,5 +1,6 @@
 use crate::make_smart_pointer;
-use crate::services::cluster::actor::PeerAddr;
+
+use crate::services::cluster::actors::actor::PeerAddr;
 use crate::services::cluster::inbound::request::HandShakeRequest;
 use crate::services::cluster::inbound::request::HandShakeRequestEnum;
 
@@ -55,7 +56,7 @@ impl InboundStream {
         self.write(QueryIO::SimpleString(
             "FULLRESYNC 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb 0".to_string(),
         ))
-            .await?;
+        .await?;
 
         Ok((repl_id, offset))
     }

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -1,8 +1,6 @@
+use super::actors::actor::{ClusterActor, PeerAddr};
+use super::actors::command::{ClusterCommand, PeerKind};
 use crate::make_smart_pointer;
-use crate::services::cluster::actor::ClusterActor;
-use crate::services::cluster::actor::PeerAddr;
-use crate::services::cluster::command::ClusterCommand;
-use crate::services::cluster::command::PeerKind;
 use crate::services::cluster::inbound::stream::InboundStream;
 use crate::services::cluster::outbound::stream::OutboundStream;
 use crate::services::config::replication::Replication;

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -59,8 +59,8 @@ impl ClusterManager {
             stream: peer_stream.0,
             peer_kind: PeerKind::peer_kind(&self_repl_id, &repl_id),
         })
-            .await
-            .unwrap();
+        .await
+        .unwrap();
     }
 
     async fn disseminate_peers(&self, stream: &mut TcpStream) -> anyhow::Result<()> {
@@ -89,7 +89,7 @@ impl ClusterManager {
             stream: outbound_stream.0,
             peer_kind: PeerKind::Master,
         })
-            .await?;
+        .await?;
 
         for peer in peer_list {
             let mut peer_stream = OutboundStream(TcpStream::connect(peer).await?);

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -1,5 +1,4 @@
-pub mod actor;
-mod command;
-pub mod manager;
+mod actors;
 pub mod inbound;
+pub mod manager;
 pub mod outbound;

--- a/src/services/cluster/outbound/mod.rs
+++ b/src/services/cluster/outbound/mod.rs
@@ -1,2 +1,2 @@
-pub mod stream;
 pub mod response;
+pub mod stream;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,3 @@
-use redis_starter_rust::services::cluster::actor::{ClusterActor, PeerAddr};
 use redis_starter_rust::services::config::actor::ConfigActor;
 use redis_starter_rust::services::config::manager::ConfigManager;
 use redis_starter_rust::services::interface::{TCancellationTokenFactory, TRead};


### PR DESCRIPTION

`PeerListeningActor` is responsible for listening to incoming messages from a peer.

Message from a peer is one of events that can trigger a change in the cluster state.

As the system has to keep listening to incoming messages, it is implemented as an actor, run in the background.

To take a control of the actor, PeerListenerHandler is used, which can kill the listening process and return the connected stream.

closes #132 