### PR TITLE
feat: master heartbeat implementation

### DIFF
--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -1,6 +1,6 @@
-use super::command::{ClusterCommand, ClusterWriteCommand, PeerKind};
+use super::command::{ClusterCommand, ClusterWriteCommand};
 use super::listening_actor::{ClusterReadConnected, ListeningActorKillTrigger, PeerListeningActor};
-use crate::make_smart_pointer;
+use super::types::{PeerAddr, PeerKind};
 
 use crate::services::interface::TWrite;
 use crate::services::query_io::QueryIO;
@@ -16,10 +16,6 @@ pub struct ClusterActor {
     // PeerAddr is cluster ip:{cluster_port} of peer
     members: BTreeMap<PeerAddr, Peer>,
 }
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
-pub struct PeerAddr(pub String);
-make_smart_pointer!(PeerAddr, String);
 
 impl ClusterActor {
     async fn heartbeat(&mut self) {

--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -1,7 +1,7 @@
 use crate::services::query_io::QueryIO;
 use tokio::net::TcpStream;
 
-use super::actor::PeerAddr;
+use super::types::{PeerAddr, PeerKind};
 
 pub enum ClusterCommand {
     AddPeer { peer_addr: PeerAddr, stream: TcpStream, peer_kind: PeerKind },
@@ -21,19 +21,24 @@ pub enum ClusterWriteCommand {
     Ping,
 }
 
-#[derive(Clone)]
-pub enum PeerKind {
-    Peer,
-    Replica,
-    Master,
+pub enum MasterCommand {
+    Ping,
+    Replicate { query: QueryIO },
+}
+pub enum PeerCommand {
+    Ping,
 }
 
-impl PeerKind {
-    pub fn peer_kind(self_repl_id: &str, other_repl_id: &str) -> Self {
-        if self_repl_id == "?" || self_repl_id == other_repl_id {
-            Self::Replica
-        } else {
-            Self::Peer
+impl TryFrom<QueryIO> for MasterCommand {
+    type Error = anyhow::Error;
+    fn try_from(query: QueryIO) -> anyhow::Result<Self> {
+        match query {
+            QueryIO::SimpleString(s) => match s.to_lowercase().as_str() {
+                "ping" => Ok(Self::Ping),
+
+                _ => todo!(),
+            },
+            _ => todo!(),
         }
     }
 }

--- a/src/services/cluster/actors/listening_actor.rs
+++ b/src/services/cluster/actors/listening_actor.rs
@@ -2,8 +2,9 @@
 /// Message from a peer is one of events that can trigger a change in the cluster state.
 /// As it has to keep listening to incoming messages, it is implemented as an actor, run in the background.
 /// To take a control of the actor, PeerListenerHandler is used, which can kill the listening process and return the connected stream.
-use super::command::ClusterCommand;
+use super::command::{ClusterCommand, MasterCommand};
 use crate::services::interface::TRead;
+use crate::services::query_io::QueryIO;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::select;
 use tokio::sync::mpsc::Sender;
@@ -57,9 +58,30 @@ impl PeerListeningActor {
         }
     }
     async fn listen_master_stream(read_buf: &mut OwnedReadHalf) {
-        while let Ok(values) = read_buf.read_values().await {
-            let _ = values;
+        while let Ok(cmds) = Self::read_command::<MasterCommand>(read_buf).await {
+            for cmd in cmds {
+                match cmd {
+                    MasterCommand::Ping => {
+                        println!("[INFO] Received ping from master");
+                    }
+                    MasterCommand::Replicate { query } => {}
+                }
+            }
         }
+    }
+
+    async fn read_command<T>(read_buf: &mut OwnedReadHalf) -> anyhow::Result<Vec<T>>
+    where
+        T: std::convert::TryFrom<QueryIO>,
+        T::Error: Into<anyhow::Error>,
+    {
+        read_buf
+            .read_values()
+            .await?
+            .into_iter()
+            .map(T::try_from)
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)
     }
 }
 

--- a/src/services/cluster/actors/mod.rs
+++ b/src/services/cluster/actors/mod.rs
@@ -1,3 +1,4 @@
 pub(super) mod actor;
 pub mod command;
 mod listening_actor;
+pub(super) mod types;

--- a/src/services/cluster/actors/types.rs
+++ b/src/services/cluster/actors/types.rs
@@ -1,0 +1,22 @@
+use crate::make_smart_pointer;
+
+#[derive(Clone)]
+pub enum PeerKind {
+    Peer,
+    Replica,
+    Master,
+}
+
+impl PeerKind {
+    pub fn peer_kind(self_repl_id: &str, other_repl_id: &str) -> Self {
+        if self_repl_id == "?" || self_repl_id == other_repl_id {
+            Self::Replica
+        } else {
+            Self::Peer
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+pub struct PeerAddr(pub String);
+make_smart_pointer!(PeerAddr, String);

--- a/src/services/cluster/inbound/stream.rs
+++ b/src/services/cluster/inbound/stream.rs
@@ -1,6 +1,6 @@
 use crate::make_smart_pointer;
 
-use crate::services::cluster::actors::actor::PeerAddr;
+use crate::services::cluster::actors::types::PeerAddr;
 use crate::services::cluster::inbound::request::HandShakeRequest;
 use crate::services::cluster::inbound::request::HandShakeRequestEnum;
 

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -1,5 +1,6 @@
-use super::actors::actor::{ClusterActor, PeerAddr};
-use super::actors::command::{ClusterCommand, PeerKind};
+use super::actors::actor::ClusterActor;
+use super::actors::command::ClusterCommand;
+use super::actors::types::{PeerAddr, PeerKind};
 use crate::make_smart_pointer;
 use crate::services::cluster::inbound::stream::InboundStream;
 use crate::services::cluster::outbound::stream::OutboundStream;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -14,9 +14,11 @@ use tokio::net::tcp::WriteHalf;
 
 use tokio::net::TcpStream;
 
-pub static PORT_DISTRIBUTOR: std::sync::atomic::AtomicU16 =
-    std::sync::atomic::AtomicU16::new(49152);
+static PORT_DISTRIBUTOR: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(49152);
 
+pub fn get_available_port() -> u16 {
+    PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+}
 pub struct TestStreamHandler<'a> {
     pub read: ReadHalf<'a>,
     pub write: WriteHalf<'a>,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,13 +5,17 @@ use redis_starter_rust::services::query_io::QueryIO;
 use redis_starter_rust::{make_smart_pointer, StartUpFacade, TNotifyStartUp};
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
+
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::ReadHalf;
 use tokio::net::tcp::WriteHalf;
-use tokio::net::TcpListener;
+
 use tokio::net::TcpStream;
+
+pub static PORT_DISTRIBUTOR: std::sync::atomic::AtomicU16 =
+    std::sync::atomic::AtomicU16::new(49152);
 
 pub struct TestStreamHandler<'a> {
     pub read: ReadHalf<'a>,
@@ -54,7 +58,7 @@ pub async fn init_config_manager_with_free_port() -> ConfigManager {
     let config = ConfigActor::default();
     let mut manager = ConfigManager::new(config);
 
-    manager.port = find_free_port_in_range(49152, 65535).await.unwrap();
+    manager.port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     manager
 }
 
@@ -63,19 +67,11 @@ pub async fn init_slave_config_manager_with_free_port(master_port: u16) -> Confi
     config.replication.master_host = Some("localhost".to_string());
     config.replication.master_port = Some(master_port);
     let mut manager = ConfigManager::new(config);
-    manager.port = find_free_port_in_range(49152, 65535).await.unwrap();
+    manager.port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
     manager
 }
 // scan for available port
-pub async fn find_free_port_in_range(start: u16, end: u16) -> Option<u16> {
-    for port in start..=end {
-        if TcpListener::bind(format!("127.0.0.1:{}", port)).await.is_ok() {
-            return Some(port);
-        }
-    }
-    None
-}
 
 pub struct StartFlag(pub Arc<tokio::sync::Notify>);
 
@@ -129,12 +125,17 @@ pub fn run_server_process(port: u16, replicaof: Option<String>) -> TestProcessCh
     )
 }
 
-pub fn wait_for_message<T: Read>(read: T, target: &str) {
+pub fn wait_for_message<T: Read>(read: T, target: &str, target_count: usize) {
     let mut buf = BufReader::new(read).lines();
+    let mut cnt = 1;
 
     while let Some(Ok(line)) = buf.next() {
         if line == target {
-            break;
+            if cnt == target_count {
+                break;
+            } else {
+                cnt += 1;
+            }
         }
     }
 }

--- a/tests/test_disseminate_peers.rs
+++ b/tests/test_disseminate_peers.rs
@@ -1,12 +1,12 @@
 /// After three-way handshake, client will receive peers from the master server
 mod common;
-use common::{run_server_process, wait_for_message, PORT_DISTRIBUTOR};
+use common::{get_available_port, run_server_process, wait_for_message};
 
 #[tokio::test]
 async fn test_disseminate_peers() {
     // GIVEN - master server configuration
     // Find free ports for the master and replica
-    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let master_port = get_available_port();
 
     // Start the master server as a child process
     let mut master_process = run_server_process(master_port, None);
@@ -19,7 +19,7 @@ async fn test_disseminate_peers() {
     );
 
     // WHEN run replica
-    let replica_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let replica_port = get_available_port();
     let mut replica_process =
         run_server_process(replica_port, Some(format!("localhost:{}", master_port)));
 

--- a/tests/test_disseminate_peers.rs
+++ b/tests/test_disseminate_peers.rs
@@ -1,12 +1,12 @@
 /// After three-way handshake, client will receive peers from the master server
 mod common;
-use common::{find_free_port_in_range, run_server_process, wait_for_message};
+use common::{run_server_process, wait_for_message, PORT_DISTRIBUTOR};
 
 #[tokio::test]
 async fn test_disseminate_peers() {
     // GIVEN - master server configuration
     // Find free ports for the master and replica
-    let master_port = find_free_port_in_range(6000, 6553).await.unwrap();
+    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
     // Start the master server as a child process
     let mut master_process = run_server_process(master_port, None);
@@ -15,14 +15,15 @@ async fn test_disseminate_peers() {
     wait_for_message(
         master_stdout.expect("failed to take stdout"),
         format!("listening peer connection on localhost:{}...", master_port + 10000).as_str(),
+        1,
     );
 
     // WHEN run replica
-    let replica_port = find_free_port_in_range(6000, 6553).await.unwrap();
+    let replica_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let mut replica_process =
         run_server_process(replica_port, Some(format!("localhost:{}", master_port)));
 
     // Read stdout from the replica process
     let mut stdout = replica_process.stdout.take();
-    wait_for_message(stdout.take().unwrap(), "[INFO] Received peer list: []");
+    wait_for_message(stdout.take().unwrap(), "[INFO] Received peer list: []", 1);
 }

--- a/tests/test_handshake.rs
+++ b/tests/test_handshake.rs
@@ -9,7 +9,7 @@
 ///
 ///
 use common::{
-    run_server_process, start_test_server, wait_for_message, TestStreamHandler, PORT_DISTRIBUTOR,
+    get_available_port, run_server_process, start_test_server, wait_for_message, TestStreamHandler,
 };
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
@@ -26,7 +26,7 @@ async fn test_master_threeway_handshake() {
     let mut manager = ConfigManager::new(config);
 
     // ! `peer_bind_addr` is bind_addr dedicated for peer connections
-    manager.port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    manager.port = get_available_port();
     let master_cluster_bind_addr = manager.peer_bind_addr();
 
     let _ = start_test_server(CancellationTokenFactory, manager).await;
@@ -72,7 +72,7 @@ async fn test_master_threeway_handshake() {
 async fn test_slave_threeway_handshake() {
     // GIVEN - master server configuration
     // Find free ports for the master and replica
-    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let master_port = get_available_port();
 
     // Start the master server as a child process
     let mut master_process = run_server_process(master_port, None);
@@ -85,7 +85,7 @@ async fn test_slave_threeway_handshake() {
     );
 
     // WHEN run replica
-    let replica_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let replica_port = get_available_port();
     let mut replica_process =
         run_server_process(replica_port, Some(format!("localhost:{}", master_port)));
 

--- a/tests/test_heartbeat.rs
+++ b/tests/test_heartbeat.rs
@@ -1,17 +1,16 @@
-//! This file contains tests for heartbeat between server and client
+//! This file contains tests for heartbeat between master and replica
 //! Any interconnected system should have a heartbeat mechanism to ensure that the connection is still alive
-//! In this case, the server will send PING message to the client and the client will respond with PONG message
-//! The following test simulate the replica server with the use of TcpStream.
-//! Actual implementation will be standalone replica server that will be connected to the master server
+//! In this case, the server will send PING message to the replica and the replica will respond with PONG message
+
 mod common;
-use common::{run_server_process, wait_for_message, PORT_DISTRIBUTOR};
+use common::{get_available_port, run_server_process, wait_for_message};
 
 #[tokio::test]
 async fn test_heartbeat() {
     // GIVEN
     // run the random server on a random port
 
-    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let master_port = get_available_port();
 
     let mut master_process = run_server_process(master_port, None);
     let master_stdout = master_process.stdout.take();
@@ -21,7 +20,7 @@ async fn test_heartbeat() {
         1,
     );
 
-    let replica_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let replica_port = get_available_port();
     let mut replica_process =
         run_server_process(replica_port, Some(format!("localhost:{}", master_port)));
 
@@ -34,7 +33,7 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
     // GIVEN
     // run the random server on a random port
 
-    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let master_port = get_available_port();
 
     let mut master_process = run_server_process(master_port, None);
     let master_stdout = master_process.stdout.take();

--- a/tests/test_heartbeat.rs
+++ b/tests/test_heartbeat.rs
@@ -3,74 +3,67 @@
 //! In this case, the server will send PING message to the client and the client will respond with PONG message
 //! The following test simulate the replica server with the use of TcpStream.
 //! Actual implementation will be standalone replica server that will be connected to the master server
-
 mod common;
-
-use std::time::Duration;
-
-use common::{find_free_port_in_range, start_test_server, threeway_handshake_helper};
-use redis_starter_rust::{
-    adapters::cancellation_token::CancellationTokenFactory,
-    services::{
-        config::{actor::ConfigActor, manager::ConfigManager},
-        interface::TStream,
-    },
-};
-use tokio::{net::TcpStream, task::JoinHandle, time::timeout};
-
-// The following simulate the replica server by creating a TcpStream that will be connected by the master server
-async fn receive_server_ping_from_replica_stream(
-    master_cluster_bind_addr: String,
-) -> JoinHandle<()> {
-    let mut stream_handler = TcpStream::connect(master_cluster_bind_addr.clone()).await.unwrap();
-    threeway_handshake_helper(&mut stream_handler, None).await;
-
-    tokio::spawn(async move {
-        let mut count = 0;
-        while let Ok(values) = stream_handler.read_value().await {
-            if count == 5 {
-                break;
-            }
-            // TODO PING may not be used. It is just a placeholder
-            assert_eq!(values.serialize(), "+PING\r\n");
-            count += 1;
-        }
-    })
-}
+use common::{run_server_process, wait_for_message, PORT_DISTRIBUTOR};
 
 #[tokio::test]
 async fn test_heartbeat() {
     // GIVEN
     // run the random server on a random port
-    let config = ConfigActor::default();
-    let mut manager = ConfigManager::new(config);
-    manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
-    let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager).await;
 
-    // run the client bind stream on a random port so it can later get connection request from server
-    let handler = receive_server_ping_from_replica_stream(master_cluster_bind_addr.clone()).await;
+    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-    //WHEN we await on handler, it will receive 5 PING messages
-    timeout(Duration::from_secs(6), handler).await.unwrap().unwrap();
+    let mut master_process = run_server_process(master_port, None);
+    let master_stdout = master_process.stdout.take();
+    wait_for_message(
+        master_stdout.expect("failed to take stdout"),
+        format!("listening peer connection on localhost:{}...", master_port + 10000).as_str(),
+        1,
+    );
+
+    let replica_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let mut replica_process =
+        run_server_process(replica_port, Some(format!("localhost:{}", master_port)));
+
+    let mut stdout = replica_process.stdout.take();
+    wait_for_message(stdout.take().unwrap(), "[INFO] Received ping from master", 2);
 }
 
 #[tokio::test]
 async fn test_heartbeat_sent_to_multiple_replicas() {
     // GIVEN
     // run the random server on a random port
-    let config = ConfigActor::default();
-    let mut manager = ConfigManager::new(config);
-    manager.port = find_free_port_in_range(6000, 6553).await.unwrap();
-    let master_cluster_bind_addr = manager.peer_bind_addr();
-    let _ = start_test_server(CancellationTokenFactory, manager).await;
 
-    // run the client bind stream on a random port so it can later get connection request from server
-    let repl1_handler =
-        receive_server_ping_from_replica_stream(master_cluster_bind_addr.clone()).await;
-    let repl2_handler =
-        receive_server_ping_from_replica_stream(master_cluster_bind_addr.clone()).await;
+    let master_port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-    //WHEN we await on handler, it will receive 5 PING messages
-    let _ = tokio::join!(repl1_handler, repl2_handler);
+    let mut master_process = run_server_process(master_port, None);
+    let master_stdout = master_process.stdout.take();
+    wait_for_message(
+        master_stdout.expect("failed to take stdout"),
+        format!("listening peer connection on localhost:{}...", master_port + 10000).as_str(),
+        1,
+    );
+
+    // To prevent port race condition, we need to preallocate the ports
+    let replica_port1 = 60002;
+    let replica_port2 = 60003;
+
+    // WHEN
+    let mut r1 = run_server_process(replica_port1, Some(format!("localhost:{}", master_port)));
+
+    let mut r2 = run_server_process(replica_port2, Some(format!("localhost:{}", master_port)));
+
+    let t_h1 = std::thread::spawn(move || {
+        let mut stdout = r1.stdout.take();
+        wait_for_message(stdout.take().unwrap(), "[INFO] Received ping from master", 2);
+    });
+
+    let t_h2 = std::thread::spawn(move || {
+        let mut stdout = r2.stdout.take();
+        wait_for_message(stdout.take().unwrap(), "[INFO] Received ping from master", 2);
+    });
+
+    //Then it should finish
+    t_h1.join().unwrap();
+    t_h2.join().unwrap();
 }

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{start_test_server, threeway_handshake_helper, PORT_DISTRIBUTOR};
+use common::{get_available_port, start_test_server, threeway_handshake_helper};
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
     services::{
@@ -54,8 +54,7 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
     let manager = ConfigManager::new(config);
     let master_cluster_bind_addr = manager.peer_bind_addr();
 
-    let replica_server_cluster_port =
-        PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let replica_server_cluster_port = get_available_port();
     let replica_cluster_addr = format!("127.0.0.1:{}", replica_server_cluster_port);
     let _ = start_test_server(CancellationTokenFactory, manager.clone()).await;
 

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{find_free_port_in_range, start_test_server, threeway_handshake_helper};
+use common::{start_test_server, threeway_handshake_helper, PORT_DISTRIBUTOR};
 use redis_starter_rust::{
     adapters::cancellation_token::CancellationTokenFactory,
     services::{
@@ -54,7 +54,8 @@ async fn test_heartbeat_sent_to_multiple_replicas() {
     let manager = ConfigManager::new(config);
     let master_cluster_bind_addr = manager.peer_bind_addr();
 
-    let replica_server_cluster_port = find_free_port_in_range(50000, 65535).await.unwrap();
+    let replica_server_cluster_port =
+        PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let replica_cluster_addr = format!("127.0.0.1:{}", replica_server_cluster_port);
     let _ = start_test_server(CancellationTokenFactory, manager.clone()).await;
 


### PR DESCRIPTION
- Testcode refactored into process-based one
- PORT_DISTRIBUTER used for simplicity
- Listener specific command implemented
- Heartbeat tested