### PR TITLE
refactor: move replication in preparation for leader election

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,5 +10,6 @@ async fn main() -> anyhow::Result<()> {
     let config_manager = ConfigManager::new(ConfigActor::default());
 
     let mut start_up_runner = StartUpFacade::new(CancellationTokenFactory, config_manager);
+
     start_up_runner.run(()).await
 }

--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -1,12 +1,16 @@
 use crate::services::query_io::QueryIO;
 use tokio::net::TcpStream;
 
-use super::types::{PeerAddr, PeerKind};
+use super::{
+    replication::Replication,
+    types::{PeerAddr, PeerKind},
+};
 
 pub enum ClusterCommand {
     AddPeer { peer_addr: PeerAddr, stream: TcpStream, peer_kind: PeerKind },
     RemovePeer(PeerAddr),
     GetPeers(tokio::sync::oneshot::Sender<Vec<PeerAddr>>),
+    ReplicationInfo(tokio::sync::oneshot::Sender<Replication>),
     Write(ClusterWriteCommand),
 }
 

--- a/src/services/cluster/actors/mod.rs
+++ b/src/services/cluster/actors/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod actor;
 pub mod command;
 mod listening_actor;
+pub(crate) mod replication;
 pub(super) mod types;

--- a/src/services/cluster/actors/replication.rs
+++ b/src/services/cluster/actors/replication.rs
@@ -1,16 +1,30 @@
-#[derive(Debug, Clone, Default)]
+use crate::services::config::init::get_env;
+use std::sync::atomic::AtomicBool;
+pub static IS_MASTER_MODE: AtomicBool = AtomicBool::new(true);
+
+#[derive(Debug, Clone)]
 pub struct Replication {
-    pub connected_slaves: u16,             // The number of connected replicas
-    pub master_replid: String, // The replication ID of the master example: 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb
-    master_repl_offset: u64,   // The replication offset of the master example: 0
-    second_repl_offset: i16,   // -1
-    repl_backlog_active: usize, // 0
-    repl_backlog_size: usize,  // 1048576
+    pub(crate) connected_slaves: u16, // The number of connected replicas
+    pub(crate) master_replid: String, // The replication ID of the master example: 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb
+    master_repl_offset: u64,          // The replication offset of the master example: 0
+    second_repl_offset: i16,          // -1
+    repl_backlog_active: usize,       // 0
+    repl_backlog_size: usize,         // 1048576
     repl_backlog_first_byte_offset: usize, // 0
 
-    pub master_host: Option<String>,
-    pub master_port: Option<u16>,
+    pub(crate) master_host: Option<String>,
+    pub(crate) master_port: Option<u16>,
 }
+
+impl Default for Replication {
+    fn default() -> Self {
+        let replication = Replication::new(get_env().replicaof.clone());
+        IS_MASTER_MODE
+            .store(replication.master_port.is_none(), std::sync::atomic::Ordering::Relaxed);
+        replication
+    }
+}
+
 impl Replication {
     pub fn new(replicaof: Option<(String, String)>) -> Self {
         Replication {

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -1,4 +1,4 @@
-mod actors;
+pub(crate) mod actors;
 pub mod inbound;
 pub mod manager;
 pub mod outbound;

--- a/src/services/config/actor.rs
+++ b/src/services/config/actor.rs
@@ -1,6 +1,3 @@
-use std::thread::sleep;
-use std::time::Duration;
-
 use super::command::ConfigMessage;
 use super::command::ConfigResource;
 use super::command::ConfigResponse;

--- a/src/services/config/command.rs
+++ b/src/services/config/command.rs
@@ -1,7 +1,5 @@
 use tokio::sync::oneshot;
 
-use super::replication::Replication;
-
 /// ConfigMessage is a message that can be sent to the ConfigManager.
 /// It can be either a query or a command.
 /// If it is a query, it will have a callback to send the response back to the caller.
@@ -24,21 +22,20 @@ impl ConfigQuery {
         let _ = self.callback.send(res);
     }
 }
+
+#[derive(Debug)]
 pub enum ConfigResource {
     Dir,
     DbFileName,
     FilePath,
-    ReplicationInfo,
 }
 
 pub enum ConfigResponse {
     Dir(String),
     DbFileName(String),
     FilePath(String),
-    ReplicationInfo(Replication),
 }
 
 pub enum ConfigCommand {
-    ReplicaPing,
     SetDbFileName(String),
 }

--- a/src/services/config/init.rs
+++ b/src/services/config/init.rs
@@ -6,6 +6,8 @@ pub(crate) struct Environment {
     pub(crate) replicaof: Option<(String, String)>,
     pub(crate) dir: String,
     pub(crate) dbfilename: String,
+    pub(crate) port: u16,
+    pub(crate) host: String,
 }
 
 impl Environment {
@@ -15,11 +17,12 @@ impl Environment {
                 replicaof
             }
             {
+                port = 6379,
+                host = "localhost".to_string(),
                 dir = ".".to_string(),
                 dbfilename = "dump.rdb".to_string()
             }
         );
-
         let replicaof = replicaof.map(|host_port| {
             host_port
                 .split_once(':')
@@ -29,7 +32,7 @@ impl Environment {
         });
         IS_MASTER_MODE.store(replicaof.is_none(), std::sync::atomic::Ordering::Relaxed);
 
-        Self { replicaof, dir, dbfilename }
+        Self { replicaof, dir, dbfilename, port, host }
     }
 }
 

--- a/src/services/config/init.rs
+++ b/src/services/config/init.rs
@@ -1,0 +1,40 @@
+use std::sync::OnceLock;
+
+use crate::{env_var, services::cluster::actors::replication::IS_MASTER_MODE};
+
+pub(crate) struct Environment {
+    pub(crate) replicaof: Option<(String, String)>,
+    pub(crate) dir: String,
+    pub(crate) dbfilename: String,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        env_var!(
+            {
+                replicaof
+            }
+            {
+                dir = ".".to_string(),
+                dbfilename = "dump.rdb".to_string()
+            }
+        );
+
+        let replicaof = replicaof.map(|host_port| {
+            host_port
+                .split_once(':')
+                .map(|(a, b)| (a.to_string(), b.to_string()))
+                .into_iter()
+                .collect::<(_, _)>()
+        });
+        IS_MASTER_MODE.store(replicaof.is_none(), std::sync::atomic::Ordering::Relaxed);
+
+        Self { replicaof, dir, dbfilename }
+    }
+}
+
+static E: OnceLock<Environment> = OnceLock::new();
+
+pub(crate) fn get_env() -> &'static Environment {
+    E.get_or_init(Environment::new)
+}

--- a/src/services/config/manager.rs
+++ b/src/services/config/manager.rs
@@ -2,12 +2,9 @@ use super::actor::ConfigActor;
 use super::command::ConfigCommand;
 use super::command::ConfigMessage;
 use super::command::ConfigQuery;
-
 use super::ConfigResource;
 use super::ConfigResponse;
-use crate::env_var;
-use std::thread::sleep;
-use std::time::Duration;
+use crate::services::config::init::get_env;
 use std::time::SystemTime;
 
 use tokio::fs::try_exists;
@@ -36,16 +33,13 @@ impl ConfigManager {
         let (tx, inbox) = tokio::sync::mpsc::channel(20);
 
         config.handle(inbox);
-        env_var!({}{
-            port = 6379,
-            host = "localhost".to_string()
-        });
 
+        let env = get_env();
         Self {
             config: tx,
             startup_time: SystemTime::now(),
-            port,
-            host: Box::leak(host.into_boxed_str()),
+            port: env.port,
+            host: Box::leak(env.host.clone().into_boxed_str()),
             // cluster_mode_watcher,
         }
     }

--- a/src/services/config/manager.rs
+++ b/src/services/config/manager.rs
@@ -2,10 +2,12 @@ use super::actor::ConfigActor;
 use super::command::ConfigCommand;
 use super::command::ConfigMessage;
 use super::command::ConfigQuery;
-use super::replication::Replication;
+
 use super::ConfigResource;
 use super::ConfigResponse;
 use crate::env_var;
+use std::thread::sleep;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use tokio::fs::try_exists;
@@ -18,7 +20,7 @@ pub struct ConfigManager {
     pub(crate) startup_time: SystemTime,
     pub port: u16,
     pub(crate) host: &'static str,
-    pub(crate) cluster_mode_watcher: tokio::sync::watch::Receiver<bool>,
+    // pub(crate) cluster_mode_watcher: tokio::sync::watch::Receiver<bool>,
 }
 
 impl std::ops::Deref for ConfigManager {
@@ -33,8 +35,7 @@ impl ConfigManager {
     pub fn new(config: ConfigActor) -> Self {
         let (tx, inbox) = tokio::sync::mpsc::channel(20);
 
-        let cluster_mode_watcher = config.handle(inbox);
-
+        config.handle(inbox);
         env_var!({}{
             port = 6379,
             host = "localhost".to_string()
@@ -45,22 +46,14 @@ impl ConfigManager {
             startup_time: SystemTime::now(),
             port,
             host: Box::leak(host.into_boxed_str()),
-            cluster_mode_watcher,
+            // cluster_mode_watcher,
         }
-    }
-
-    // Park the task until the cluster mode changes - error means notifier has been dropped
-    pub(crate) async fn wait_until_cluster_mode_changed(&mut self) -> anyhow::Result<()> {
-        self.cluster_mode_watcher.changed().await?;
-        Ok(())
-    }
-    pub(crate) fn cluster_mode(&mut self) -> bool {
-        *self.cluster_mode_watcher.borrow_and_update()
     }
 
     // The following is used on startup and check if the file exists
     pub async fn try_filepath(&self) -> anyhow::Result<Option<String>> {
         let res = self.route_query(ConfigResource::FilePath).await?;
+
         let ConfigResponse::FilePath(file_path) = res else {
             return Ok(None);
         };
@@ -101,15 +94,6 @@ impl ConfigManager {
             return Err(anyhow::anyhow!("Failed to get file path"));
         };
         Ok(file_path)
-    }
-
-    pub async fn replication_info(&self) -> anyhow::Result<Replication> {
-        let res = self.route_query(ConfigResource::ReplicationInfo).await?;
-
-        let ConfigResponse::ReplicationInfo(info) = res else {
-            return Err(anyhow::anyhow!("Failed to get replication info"));
-        };
-        Ok(info)
     }
 
     pub async fn route_query(&self, resource: ConfigResource) -> anyhow::Result<ConfigResponse> {

--- a/src/services/config/mod.rs
+++ b/src/services/config/mod.rs
@@ -1,8 +1,8 @@
 pub mod actor;
 mod command;
+pub mod init;
 pub mod macros;
 pub mod manager;
-pub mod replication;
 
 pub use command::ConfigCommand;
 pub use command::ConfigMessage;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -64,15 +64,6 @@ pub async fn init_config_manager_with_free_port() -> ConfigManager {
     manager
 }
 
-pub async fn init_slave_config_manager_with_free_port(master_port: u16) -> ConfigManager {
-    let mut config = ConfigActor::default();
-    config.replication.master_host = Some("localhost".to_string());
-    config.replication.master_port = Some(master_port);
-    let mut manager = ConfigManager::new(config);
-    manager.port = PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-    manager
-}
 // scan for available port
 
 pub struct StartFlag(pub Arc<tokio::sync::Notify>);

--- a/tests/test_cancellation_token.rs
+++ b/tests/test_cancellation_token.rs
@@ -12,6 +12,7 @@ use tokio::net::TcpStream;
 #[tokio::test]
 async fn test_cancellation_token() {
     // GIVEN
+
     let config = init_config_manager_with_free_port().await;
 
     let _ = start_test_server(TestCancellationTokenFactory, config.clone()).await;

--- a/tests/test_heartbeat_broadcasting.rs
+++ b/tests/test_heartbeat_broadcasting.rs
@@ -1,43 +1,4 @@
 mod common;
-use common::threeway_handshake_helper;
-use redis_starter_rust::services::interface::TStream;
-use std::collections::HashMap;
-use tokio::net::TcpListener;
-use tokio::{net::TcpStream, task::JoinHandle};
-
-async fn receive_server_ping_from_replica_stream(
-    master_cluster_bind_addr: String,
-    replica_port: u16,
-) -> JoinHandle<()> {
-    // run the fake replica server in advance
-    let mut replica_stream = TcpStream::connect(master_cluster_bind_addr.clone()).await.unwrap();
-    threeway_handshake_helper(&mut replica_stream, Some(replica_port)).await;
-
-    let listener = TcpListener::bind(format!("localhost:{}", replica_port)).await.unwrap();
-
-    let handler = tokio::spawn(async move {
-        // * replica server
-
-        // * faking the replica server
-        while let Ok((mut stream, addr)) = listener.accept().await {
-            let mut socket_hash = HashMap::new();
-            socket_hash.entry(addr).or_insert(0);
-            while let Ok(values) = stream.read_value().await {
-                if *socket_hash.get(&addr).unwrap() == 5 {
-                    break;
-                }
-                // TODO PING may not be used. It is just a placeholder
-                assert_eq!(values.serialize(), "+PING\r\n");
-                *socket_hash.get_mut(&addr).unwrap() += 1;
-            }
-            if socket_hash.values().find(|v| v >= &&5).is_some() {
-                break;
-            }
-        }
-    });
-
-    handler
-}
 
 #[tokio::test]
 #[ignore = "not yet ready"]


### PR DESCRIPTION
Currently, replication information was implemented under config which makes it difficult to draw the line between cluster actor and config actor. 

It gets worse when we implement leader election for example which inherently changes replication information.



In this PR, the following was implemented
- environment variable collector -which will be used once when we construct startup facade
- moving replication under cluster actor
- relavant refactoring