### PR TITLE
enhancement: blanket implementation for TWrite&TRead

### DIFF
--- a/src/adapters/io/tokio_file.rs
+++ b/src/adapters/io/tokio_file.rs
@@ -1,16 +1,4 @@
-use crate::services::{
-    error::IoError,
-    interface::{TWrite, TWriterFactory},
-};
-use tokio::io::AsyncWriteExt;
-
-impl TWrite for tokio::fs::File {
-    async fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
-        AsyncWriteExt::write_all(&mut (self as &mut tokio::fs::File), buf)
-            .await
-            .map_err(|e| e.kind().into())
-    }
-}
+use crate::services::interface::TWriterFactory;
 
 impl TWriterFactory for tokio::fs::File {
     async fn create_writer(filepath: String) -> anyhow::Result<tokio::fs::File> {

--- a/src/adapters/io/tokio_stream.rs
+++ b/src/adapters/io/tokio_stream.rs
@@ -4,87 +4,22 @@ use crate::services::query_io::{parse, QueryIO};
 use bytes::BytesMut;
 use std::io::ErrorKind;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::OwnedWriteHalf;
 
 impl TStream for tokio::net::TcpStream {
-    // TODO deprecated
-    async fn read_value(&mut self) -> anyhow::Result<QueryIO> {
-        let mut buffer = BytesMut::with_capacity(512);
-        self.read_bytes(&mut buffer).await?;
-        let (query_io, _) = parse(buffer)?;
-        Ok(query_io)
-    }
-
     async fn write(&mut self, value: QueryIO) -> Result<(), IoError> {
-        self.write_all(value.serialize().as_bytes()).await.map_err(|e| {
-            eprintln!("error = {:?}", e);
-            Into::<IoError>::into(e.kind())
-        })
+        self.write_all(value.serialize().as_bytes())
+            .await
+            .map_err(|e| Into::<IoError>::into(e.kind()))
     }
 }
 
-impl TWrite for OwnedWriteHalf {
+impl<T: AsyncWriteExt + std::marker::Unpin + Sync + Send> TWrite for T {
     async fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
         self.write_all(buf).await.map_err(|e| Into::<IoError>::into(e.kind()))
     }
 }
 
-impl TRead for tokio::net::tcp::OwnedReadHalf {
-    // TCP doesn't inherently delimit messages.
-    // The data arrives in a continuous stream of bytes. And
-    // we might not receive all the data in one go.
-    // So, we need to read the data in chunks until we have received all the data for the message.
-    async fn read_bytes(&mut self, buffer: &mut BytesMut) -> Result<(), std::io::Error> {
-        // fixed size buffer
-        let mut temp_buffer = [0u8; 512];
-        loop {
-            let bytes_read = self.read(&mut temp_buffer).await?;
-
-            // If no bytes are read, it suggests that the no more data will be received for this message.
-            if bytes_read == 0 {
-                break;
-            }
-
-            // Extend the buffer with the newly read data
-            buffer.extend_from_slice(&temp_buffer[..bytes_read]);
-
-            // If fewer bytes than the buffer size are read, it suggests that
-            // - The sender has sent all the data currently available for this message.
-            // - You have reached the end of the message.
-            if bytes_read < temp_buffer.len() {
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    async fn read_values(&mut self) -> anyhow::Result<Vec<QueryIO>> {
-        let mut buffer = BytesMut::with_capacity(512);
-        self.read_bytes(&mut buffer).await?;
-
-        let mut parsed_values = Vec::new();
-        let mut remaining_buffer = buffer;
-
-        while !remaining_buffer.is_empty() {
-            match parse(remaining_buffer.clone()) {
-                Ok((query_io, consumed)) => {
-                    parsed_values.push(query_io);
-
-                    // * Remove the parsed portion from the buffer
-                    remaining_buffer = remaining_buffer.split_off(consumed);
-                }
-                Err(e) => {
-                    // Handle parsing errors
-                    // You might want to log the error or handle it differently based on your use case
-                    return Err(anyhow::anyhow!("Parsing error: {:?}", e));
-                }
-            }
-        }
-        Ok(parsed_values)
-    }
-}
-
-impl TRead for tokio::net::TcpStream {
+impl<T: AsyncReadExt + std::marker::Unpin + Sync + Send> TRead for T {
     // TCP doesn't inherently delimit messages.
     // The data arrives in a continuous stream of bytes. And
     // we might not receive all the data in one go.

--- a/src/services/client/stream.rs
+++ b/src/services/client/stream.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 use super::request::ClientRequest;
 use crate::{
     make_smart_pointer,
-    services::{interface::TStream, query_io::QueryIO},
+    services::{interface::TRead, query_io::QueryIO},
 };
 use anyhow::Context;
 use tokio::net::TcpStream;
@@ -12,47 +12,54 @@ pub struct ClientStream(pub(crate) TcpStream);
 make_smart_pointer!(ClientStream, TcpStream);
 
 impl ClientStream {
-    pub(crate) async fn extract_query(&mut self) -> anyhow::Result<ClientRequest> {
-        let query_io = self.read_value().await?;
-        match query_io {
-            QueryIO::Array(value_array) => {
-                let mut values =
-                    value_array.into_iter().map(|v| v.unpack_single_entry::<String>()).flatten();
+    pub(crate) async fn extract_query(&mut self) -> anyhow::Result<Vec<ClientRequest>> {
+        let query_ios = self.read_values().await?;
+        query_ios
+            .into_iter()
+            .map(|query_io| match query_io {
+                QueryIO::Array(value_array) => {
+                    let mut values = value_array
+                        .into_iter()
+                        .map(|v| v.unpack_single_entry::<String>())
+                        .flatten();
 
-                let command = values.next().context("Command not given")?.to_lowercase();
+                    let command = values.next().context("Command not given")?.to_lowercase();
 
-                match (command.as_str(), values.collect::<Vec<_>>().as_slice()) {
-                    ("ping", []) => Ok(ClientRequest::Ping),
-                    ("get", [key]) => Ok(ClientRequest::Get { key: key.to_string() }),
-                    ("set", [key, value]) => {
-                        Ok(ClientRequest::Set { key: key.to_string(), value: value.to_string() })
-                    }
-                    ("set", [key, value, px, expiry]) if px == "px" => {
-                        Ok(ClientRequest::SetWithExpiry {
+                    match (command.as_str(), values.collect::<Vec<_>>().as_slice()) {
+                        ("ping", []) => Ok(ClientRequest::Ping),
+                        ("get", [key]) => Ok(ClientRequest::Get { key: key.to_string() }),
+                        ("set", [key, value]) => Ok(ClientRequest::Set {
                             key: key.to_string(),
                             value: value.to_string(),
-                            expiry: Self::extract_expiry(expiry)?,
-                        })
-                    }
-                    ("delete", [key]) => Ok(ClientRequest::Delete { key: key.to_string() }),
-                    ("echo", [value]) => Ok(ClientRequest::Echo(value.to_string())),
-                    ("config", [key, value]) => {
-                        Ok(ClientRequest::Config { key: key.to_string(), value: value.to_string() })
-                    }
-
-                    ("keys", [var]) if var != &"" => {
-                        if var == "*" {
-                            return Ok(ClientRequest::Keys { pattern: None });
+                        }),
+                        ("set", [key, value, px, expiry]) if px == "px" => {
+                            Ok(ClientRequest::SetWithExpiry {
+                                key: key.to_string(),
+                                value: value.to_string(),
+                                expiry: Self::extract_expiry(expiry)?,
+                            })
                         }
-                        Ok(ClientRequest::Keys { pattern: Some(var.to_string()) })
+                        ("delete", [key]) => Ok(ClientRequest::Delete { key: key.to_string() }),
+                        ("echo", [value]) => Ok(ClientRequest::Echo(value.to_string())),
+                        ("config", [key, value]) => Ok(ClientRequest::Config {
+                            key: key.to_string(),
+                            value: value.to_string(),
+                        }),
+
+                        ("keys", [var]) if var != &"" => {
+                            if var == "*" {
+                                return Ok(ClientRequest::Keys { pattern: None });
+                            }
+                            Ok(ClientRequest::Keys { pattern: Some(var.to_string()) })
+                        }
+                        ("save", []) => Ok(ClientRequest::Save),
+                        ("info", [_unused_value]) => Ok(ClientRequest::Info),
+                        _ => Err(anyhow::anyhow!("Invalid command")),
                     }
-                    ("save", []) => Ok(ClientRequest::Save),
-                    ("info", [_unused_value]) => Ok(ClientRequest::Info),
-                    _ => Err(anyhow::anyhow!("Invalid command")),
                 }
-            }
-            _ => Err(anyhow::anyhow!("Unexpected command format")),
-        }
+                _ => Err(anyhow::anyhow!("Unexpected command format")),
+            })
+            .collect()
     }
 
     fn extract_expiry(expiry: &str) -> anyhow::Result<SystemTime> {

--- a/src/services/cluster/inbound/stream.rs
+++ b/src/services/cluster/inbound/stream.rs
@@ -7,6 +7,7 @@ use crate::services::cluster::actors::types::PeerKind;
 use crate::services::cluster::inbound::request::HandShakeRequest;
 use crate::services::cluster::inbound::request::HandShakeRequestEnum;
 
+use crate::services::interface::TRead;
 use crate::services::interface::{TGetPeerIp, TStream};
 use crate::services::query_io::QueryIO;
 use crate::services::statefuls::cache::manager::CacheManager;
@@ -83,8 +84,8 @@ impl InboundStream {
     }
 
     async fn extract_cmd(&mut self) -> anyhow::Result<HandShakeRequest> {
-        let query_io = self.read_value().await?;
-        HandShakeRequest::new(query_io)
+        let mut query_io = self.read_values().await?;
+        HandShakeRequest::new(query_io.swap_remove(0))
     }
 
     pub(crate) async fn disseminate_peers(&mut self, peers: PeerAddrs) -> anyhow::Result<()> {

--- a/src/services/interface.rs
+++ b/src/services/interface.rs
@@ -6,7 +6,6 @@ use super::query_io::QueryIO;
 
 pub trait TStream: TGetPeerIp + Send + Sync + 'static {
     // TODO deprecated
-    fn read_value(&mut self) -> impl std::future::Future<Output = anyhow::Result<QueryIO>> + Send;
 
     fn write(
         &mut self,

--- a/src/services/query_io.rs
+++ b/src/services/query_io.rs
@@ -2,7 +2,6 @@ use super::cluster::actors::peer::PeerState;
 use crate::services::statefuls::cache::CacheValue;
 use anyhow::Result;
 use bytes::BytesMut;
-use std::time::SystemTime;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum QueryIO {


### PR DESCRIPTION
Duplication on reading logic is dauntingly confusing. Let's remove it. 

On the same line, `read_value` got removed as it gives false sense of security