### PR TITLE
feat: state on replication 

### DIFF
--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -73,6 +73,7 @@ impl ClusterActor {
     }
 
     fn set_replication_id(&mut self, master_repl_id: String) {
-        self.replication.master_replid = master_repl_id
+        self.replication.master_replid = master_repl_id.clone();
+        self.replication.state.master_replid = master_repl_id;
     }
 }

--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -50,8 +50,8 @@ impl ClusterActor {
                 ClusterCommand::ReplicationInfo(sender) => {
                     let _ = sender.send(self.replication.clone());
                 }
-                ClusterCommand::SetReplicationId(master_repl_id) => {
-                    self.set_replication_id(master_repl_id);
+                ClusterCommand::SetReplicationInfo { master_repl_id, offset } => {
+                    self.set_replication_info(master_repl_id, offset);
                 }
             }
         }
@@ -72,8 +72,8 @@ impl ClusterActor {
         self.members.remove(&peer_addr);
     }
 
-    fn set_replication_id(&mut self, master_repl_id: String) {
-        self.replication.master_replid = master_repl_id.clone();
-        self.replication.state.master_replid = master_repl_id;
+    fn set_replication_info(&mut self, master_repl_id: String, offset: u64) {
+        self.replication.master_replid = master_repl_id;
+        self.replication.master_repl_offset = offset;
     }
 }

--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -10,7 +10,7 @@ pub enum ClusterCommand {
     RemovePeer(PeerAddr),
     GetPeers(tokio::sync::oneshot::Sender<PeerAddrs>),
     ReplicationInfo(tokio::sync::oneshot::Sender<Replication>),
-    SetReplicationId(String),
+    SetReplicationInfo { master_repl_id: String, offset: u64 },
     Ping,
     Replicate { query: QueryIO },
 }

--- a/src/services/cluster/actors/mod.rs
+++ b/src/services/cluster/actors/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod actor;
+pub(crate) use replication::PeerState;
 pub mod command;
 mod listening_actor;
 pub(crate) mod peer;

--- a/src/services/cluster/actors/peer.rs
+++ b/src/services/cluster/actors/peer.rs
@@ -12,7 +12,6 @@ use tokio::sync::mpsc::Sender;
 pub(crate) struct Peer {
     pub(crate) w_conn: WriteConnected,
     pub(crate) listner_kill_trigger: ListeningActorKillTrigger,
-    state: PeerState,
 }
 
 impl Peer {
@@ -34,7 +33,6 @@ impl Peer {
         Self {
             w_conn: write_connected,
             listner_kill_trigger: ListeningActorKillTrigger::new(kill_trigger, listening_task),
-            state: PeerState::default(),
         }
     }
 }
@@ -49,13 +47,6 @@ pub struct WriteConnected {
 pub(super) struct ReadConnected {
     pub stream: OwnedReadHalf,
     pub kind: PeerKind,
-}
-
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct PeerState {
-    pub(crate) term: u64,
-    pub(crate) offset: u64,
-    pub(crate) last_updated: u64,
 }
 
 impl From<(OwnedReadHalf, PeerKind)> for ReadConnected {

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -89,7 +89,7 @@ impl ClusterManager {
                 .await?
                 .establish_connection(self_port)
                 .await?
-                .set_replication_id(self)
+                .set_replication_info(self)
                 .await?
                 .deconstruct()?;
         self.send(add_peer_cmd).await?;

--- a/src/services/cluster/manager.rs
+++ b/src/services/cluster/manager.rs
@@ -13,16 +13,8 @@ use tokio::time::interval;
 #[derive(Clone)]
 pub struct ClusterManager {
     actor_handler: Sender<ClusterCommand>,
-    state: PeerState,
 }
 make_smart_pointer!(ClusterManager, Sender<ClusterCommand> => actor_handler);
-
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct PeerState {
-    pub(crate) term: u64,
-    pub(crate) offset: u64,
-    pub(crate) last_updated: u64,
-}
 
 impl ClusterManager {
     pub fn run(notifier: tokio::sync::watch::Sender<bool>) -> Self {
@@ -45,7 +37,7 @@ impl ClusterManager {
         });
 
         // TODO peer state may need to be picked up from a persistent storage on restart case
-        Self { actor_handler, state: PeerState::default() }
+        Self { actor_handler }
     }
 
     pub(crate) async fn get_peers(&self) -> anyhow::Result<PeerAddrs> {

--- a/src/services/cluster/outbound/response.rs
+++ b/src/services/cluster/outbound/response.rs
@@ -6,7 +6,7 @@ use crate::services::query_io::QueryIO;
 pub enum ConnectionResponse {
     PONG,
     OK,
-    FULLRESYNC { repl_id: String, offset: i64 },
+    FULLRESYNC { repl_id: String, offset: u64 },
     PEERS(Vec<String>),
 }
 
@@ -21,7 +21,7 @@ impl TryFrom<String> for ConnectionResponse {
                 let mut iter = var.split_whitespace();
                 let _ = iter.next();
                 let repl_id = iter.next().context("replication_id must be given")?.to_string();
-                let offset = iter.next().context("offset must be given")?.parse::<i64>()?;
+                let offset = iter.next().context("offset must be given")?.parse::<u64>()?;
                 Ok(ConnectionResponse::FULLRESYNC { repl_id, offset })
             }
 

--- a/src/services/config/manager.rs
+++ b/src/services/config/manager.rs
@@ -17,7 +17,6 @@ pub struct ConfigManager {
     pub(crate) startup_time: SystemTime,
     pub port: u16,
     pub(crate) host: &'static str,
-    // pub(crate) cluster_mode_watcher: tokio::sync::watch::Receiver<bool>,
 }
 
 impl std::ops::Deref for ConfigManager {

--- a/src/services/config/manager.rs
+++ b/src/services/config/manager.rs
@@ -39,7 +39,6 @@ impl ConfigManager {
             startup_time: SystemTime::now(),
             port: env.port,
             host: Box::leak(env.host.clone().into_boxed_str()),
-            // cluster_mode_watcher,
         }
     }
 

--- a/src/services/query_io.rs
+++ b/src/services/query_io.rs
@@ -1,9 +1,10 @@
 use std::fmt::Write;
 
-use super::cluster::actors::peer::PeerState;
 use crate::services::statefuls::cache::CacheValue;
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
+
+use super::cluster::manager::PeerState;
 
 // ! CURRENTLY, only ascii unicode(0-127) is supported
 const FILE_PREFIX: char = '\u{0066}';

--- a/src/services/query_io.rs
+++ b/src/services/query_io.rs
@@ -4,7 +4,7 @@ use crate::services::statefuls::cache::CacheValue;
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
 
-use super::cluster::manager::PeerState;
+use super::cluster::actors::PeerState;
 
 // ! CURRENTLY, only ascii unicode(0-127) is supported
 const FILE_PREFIX: char = '\u{0066}';
@@ -73,12 +73,13 @@ impl QueryIO {
             ]
             .concat()
             .into(),
-            QueryIO::PeerState(PeerState { term, offset, last_updated }) => format!(
-                "{}\r\n${}\r\n{term}\r\n${}\r\n{offset}\r\n${}\r\n{last_updated}\r\n",
+            QueryIO::PeerState(PeerState { term, offset, last_updated, master_replid }) => format!(
+                "{}\r\n${}\r\n{term}\r\n${}\r\n{offset}\r\n${}\r\n{last_updated}\r\n${}\r\n{master_replid}\r\n",
                 PEERSTATE_PREFIX,
                 term.to_string().len(),
                 offset.to_string().len(),
                 last_updated.to_string().len(),
+                master_replid.len(),
             )
             .into(),
         }
@@ -131,12 +132,13 @@ impl TryFrom<QueryIO> for PeerState {
     type Error = anyhow::Error;
 
     fn try_from(value: QueryIO) -> std::result::Result<Self, Self::Error> {
-        let QueryIO::PeerState(PeerState { term, offset, last_updated }) = value else {
+        let QueryIO::PeerState(PeerState { term, offset, last_updated, master_replid }) = value
+        else {
             return Err(anyhow::anyhow!("invalid QueryIO invariant"));
         };
 
         // SAFETY : failing on this conversion will be a bug. And the system should crash
-        Ok(PeerState { term, offset, last_updated })
+        Ok(PeerState { term, offset, last_updated, master_replid })
     }
 }
 
@@ -194,14 +196,16 @@ fn parse_peer_state(buffer: BytesMut) -> Result<(QueryIO, usize)> {
     let (term, l1) = deserialize(BytesMut::from(&buffer[len..]))?;
     let (offset, l2) = deserialize(BytesMut::from(&buffer[len + l1..]))?;
     let (last_updated, l3) = deserialize(BytesMut::from(&buffer[len + l1 + l2..]))?;
+    let (master_replid, l4) = deserialize(BytesMut::from(&buffer[len + l1 + l2 + l3..]))?;
 
     Ok((
         QueryIO::PeerState(PeerState {
             term: term.unpack_single_entry()?,
             offset: offset.unpack_single_entry()?,
             last_updated: last_updated.unpack_single_entry()?,
+            master_replid: master_replid.unpack_single_entry()?,
         }),
-        len + l1 + l2 + l3,
+        len + l1 + l2 + l3 + l4,
     ))
 }
 
@@ -320,21 +324,28 @@ fn test_parse_array() {
 #[test]
 fn test_from_bytes_to_peer_state() {
     // GIVEN
-    let buffer = BytesMut::from("^\r\n$3\r\n245\r\n$7\r\n1234329\r\n$8\r\n53999944\r\n");
+    let buffer =
+        BytesMut::from("^\r\n$3\r\n245\r\n$7\r\n1234329\r\n$8\r\n53999944\r\n$4\r\nabcd\r\n");
 
     // WHEN
     let (value, len) = deserialize(buffer).unwrap();
 
     // THEN
-    assert_eq!(len, "^\r\n$3\r\n245\r\n$7\r\n1234329\r\n$8\r\n53999944\r\n".len());
+    assert_eq!(len, "^\r\n$3\r\n245\r\n$7\r\n1234329\r\n$8\r\n53999944\r\n$4\r\nabcd\r\n".len());
     assert_eq!(
         value,
-        QueryIO::PeerState(PeerState { term: 245, offset: 1234329, last_updated: 53999944 })
+        QueryIO::PeerState(PeerState {
+            term: 245,
+            offset: 1234329,
+            last_updated: 53999944,
+            master_replid: "abcd".into()
+        })
     );
     let peer_state: PeerState = value.try_into().unwrap();
     assert_eq!(peer_state.term, 245);
     assert_eq!(peer_state.offset, 1234329);
     assert_eq!(peer_state.last_updated, 53999944);
+    assert_eq!(peer_state.master_replid, "abcd");
 }
 
 #[test]
@@ -342,20 +353,32 @@ fn test_from_peer_state_to_bytes() {
     use crate::services::query_io::QueryIO;
 
     //GIVEN
-    let peer_state = PeerState { term: 1, offset: 2, last_updated: 3 };
+    let peer_state =
+        PeerState { term: 1, offset: 2, last_updated: 3, master_replid: "your_master_repl".into() };
     //WHEN
     let peer_state_serialized: QueryIO = peer_state.into();
     let peer_state_serialized = peer_state_serialized.serialize();
     //THEN
-    assert_eq!("^\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n", peer_state_serialized);
+    assert_eq!(
+        "^\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n$16\r\nyour_master_repl\r\n",
+        peer_state_serialized
+    );
 
     //GIVEN
-    let peer_state = PeerState { term: 5, offset: 3232, last_updated: 35535300 };
+    let peer_state = PeerState {
+        term: 5,
+        offset: 3232,
+        last_updated: 35535300,
+        master_replid: "your_master_repl2".into(),
+    };
     //WHEN
     let peer_state_serialized: QueryIO = peer_state.into();
     let peer_state_serialized = peer_state_serialized.serialize();
     //THEN
-    assert_eq!("^\r\n$1\r\n5\r\n$4\r\n3232\r\n$8\r\n35535300\r\n", peer_state_serialized);
+    assert_eq!(
+        "^\r\n$1\r\n5\r\n$4\r\n3232\r\n$8\r\n35535300\r\n$17\r\nyour_master_repl2\r\n",
+        peer_state_serialized
+    );
 }
 
 #[test]


### PR DESCRIPTION
To share `PeerState`, it has to have sequence info and master repl id so when it reaches peers their identity can be  found. 

