### PR TITLE
feat: gossip method using `ReportAlive` command variant

### DIFF
--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -13,6 +13,7 @@ pub enum ClusterCommand {
     ReplicationInfo(tokio::sync::oneshot::Sender<Replication>),
     SetReplicationInfo { master_repl_id: String, offset: u64 },
     SendHeartBeat,
+    RelayHeartBeat(u8),
     Replicate { query: QueryIO },
     ReportAlive { peer_identifier: PeerIdentifier, state: PeerState },
 }

--- a/src/services/cluster/actors/command.rs
+++ b/src/services/cluster/actors/command.rs
@@ -13,7 +13,6 @@ pub enum ClusterCommand {
     ReplicationInfo(tokio::sync::oneshot::Sender<Replication>),
     SetReplicationInfo { master_repl_id: String, offset: u64 },
     SendHeartBeat,
-    RelayHeartBeat(u8),
     Replicate { query: QueryIO },
     ReportAlive { peer_identifier: PeerIdentifier, state: PeerState },
 }

--- a/src/services/cluster/actors/listening_actor.rs
+++ b/src/services/cluster/actors/listening_actor.rs
@@ -49,6 +49,11 @@ impl PeerListeningActor {
                     CommandFromSlave::HeartBeat(peer_state) => {
                         println!("[INFO] from replica rh:{}", peer_state.hop_count);
                         // TODO update peer state on cluster manager
+                        if peer_state.hop_count == 0 {
+                            return;
+                        }
+
+                        let _ = self.cluster_handler.send(ClusterCommand::SendHeartBeat).await;
                     }
                 }
             }

--- a/src/services/cluster/actors/listening_actor.rs
+++ b/src/services/cluster/actors/listening_actor.rs
@@ -49,12 +49,13 @@ impl PeerListeningActor {
                     CommandFromSlave::HeartBeat(peer_state) => {
                         println!("[INFO] from replica rh:{}", peer_state.hop_count);
                         // TODO update peer state on cluster manager
-                        if peer_state.hop_count == 0 {
-                            return;
-                        }
+
                         let _ = self
                             .cluster_handler
-                            .send(ClusterCommand::RelayHeartBeat(peer_state.hop_count - 1))
+                            .send(ClusterCommand::ReportAlive {
+                                peer_identifier: self.self_id.clone(),
+                                state: peer_state,
+                            })
                             .await;
                     }
                 }
@@ -72,13 +73,13 @@ impl PeerListeningActor {
                 match cmd {
                     CommandFromMaster::HeartBeat(peer_state) => {
                         println!("[INFO] from master rh:{}", peer_state.hop_count);
-                        self.cluster_handler
+                        let _ = self
+                            .cluster_handler
                             .send(ClusterCommand::ReportAlive {
                                 peer_identifier: self.self_id.clone(),
                                 state: peer_state,
                             })
-                            .await
-                            .unwrap();
+                            .await;
                     }
 
                     CommandFromMaster::Replicate { query: _ } => {}

--- a/src/services/cluster/actors/listening_actor.rs
+++ b/src/services/cluster/actors/listening_actor.rs
@@ -52,8 +52,10 @@ impl PeerListeningActor {
                         if peer_state.hop_count == 0 {
                             return;
                         }
-
-                        let _ = self.cluster_handler.send(ClusterCommand::SendHeartBeat).await;
+                        let _ = self
+                            .cluster_handler
+                            .send(ClusterCommand::RelayHeartBeat(peer_state.hop_count - 1))
+                            .await;
                     }
                 }
             }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -36,7 +36,7 @@ pub fn spawn_server_as_slave(master: &TestProcessChild) -> TestProcessChild {
 
 impl Drop for TestProcessChild {
     fn drop(&mut self) {
-        self.0.kill().expect("Failed to kill process");
+        let _ = self.0.kill();
     }
 }
 

--- a/tests/test_heartbeat.rs
+++ b/tests/test_heartbeat.rs
@@ -103,3 +103,33 @@ async fn test_heartbeat_hop_count() {
     wait_for_message(&mut repl2_stdout, "[INFO] from replica rh:1", 1);
     wait_for_message(&mut repl3_stdout, "[INFO] from replica rh:1", 1);
 }
+
+#[tokio::test]
+async fn test_heartbeat_hop_count_decreases_over_time() {
+    // GIVEN
+    let master_process = spawn_server_process();
+
+    let mut repl_p1 = spawn_server_as_slave(&master_process);
+    let mut repl1_stdout = repl_p1.stdout.take().unwrap();
+
+    wait_for_message(&mut repl1_stdout, "[INFO] from master rh:0", 1);
+    let mut repl_p2 = spawn_server_as_slave(&master_process);
+    wait_for_message(&mut repl1_stdout, "[INFO] from replica rh:0", 1);
+
+    let mut repl2_stdout = repl_p2.stdout.take().unwrap();
+    wait_for_message(&mut repl2_stdout, "[INFO] from replica rh:0", 1);
+
+    // WHEN run Third replica
+    let mut repl_p3 = spawn_server_as_slave(&master_process);
+    let mut repl3_stdout = repl_p3.stdout.take().unwrap();
+
+    // THEN - some of the replicas will have hop_count 1 and some will have hop_count 0
+    wait_for_message(&mut repl1_stdout, "[INFO] from master rh:1", 1);
+    wait_for_message(&mut repl1_stdout, "[INFO] from master rh:0", 1);
+
+    wait_for_message(&mut repl2_stdout, "[INFO] from replica rh:0", 1);
+    wait_for_message(&mut repl2_stdout, "[INFO] from replica rh:1", 1);
+
+    wait_for_message(&mut repl3_stdout, "[INFO] from replica rh:0", 1);
+    wait_for_message(&mut repl3_stdout, "[INFO] from replica rh:1", 1);
+}


### PR DESCRIPTION
hop_count decreasing logic implemented. 
Use of existing `ReportAlive` command variant, after update operation is done which is non fallible, try gossip if there is remaining hop count. 


resolves #192 
resolves #189 
