### PR TITLE
feat: remove nodes based on ban list

### DIFF
--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -1,7 +1,9 @@
 use crate::services::cluster::command::cluster_command::{AddPeer, ClusterCommand};
 use crate::services::cluster::peers::identifier::PeerIdentifier;
 use crate::services::cluster::peers::peer::Peer;
-use crate::services::cluster::replications::replication::{time_in_secs, PeerState, Replication};
+use crate::services::cluster::replications::replication::{
+    time_in_secs, BannedPeer, PeerState, Replication,
+};
 use crate::services::interface::TWrite;
 use crate::services::query_io::QueryIO;
 use std::collections::BTreeMap;
@@ -68,7 +70,9 @@ impl ClusterActor {
                     if self.replication.in_ban_list(&state.heartbeat_from) {
                         return;
                     }
-                    self.gossip(state).await;
+
+                    self.gossip(state.hop_count).await;
+                    self.update_on_report(state).await;
                 }
                 ClusterCommand::ForgetPeer(peer_addr, sender) => {
                     if let Ok(Some(())) = self.forget_peer(peer_addr).await {
@@ -138,22 +142,12 @@ impl ClusterActor {
         }
     }
 
-    async fn gossip(&mut self, state: PeerState) {
-        let Some(peer) = self.members.get_mut(&state.heartbeat_from) else {
-            return;
-        };
-
-        // update peer
-        peer.last_seen = Instant::now();
-        self.replication.merge_ban_list(state.ban_list);
-
-        self.cleanup_ban_list().await;
-
+    async fn gossip(&mut self, hop_count: u8) {
         // If hop_count is 0, don't send the message to other peers
-        if state.hop_count == 0 {
+        if hop_count == 0 {
             return;
         };
-        let hop_count = state.hop_count - 1;
+        let hop_count = hop_count - 1;
         self.send_heartbeat(hop_count).await;
     }
 
@@ -163,11 +157,28 @@ impl ClusterActor {
         Ok(self.remove_peer(&peer_addr).await)
     }
 
-    async fn cleanup_ban_list(&mut self) {
-        // TODO unwrap!
+    fn merge_ban_list(&mut self, ban_list: Vec<BannedPeer>) {
+        if ban_list.is_empty() {
+            return;
+        }
+        // merge, deduplicate and retain the latest
+        self.replication.ban_list.extend(ban_list);
+        self.replication
+            .ban_list
+            .sort_by_key(|node| (node.p_id.clone(), std::cmp::Reverse(node.ban_time)));
+        self.replication.ban_list.dedup_by_key(|node| node.p_id.clone());
+    }
+
+    async fn update_on_report(&mut self, state: PeerState) {
+        let Some(peer) = self.members.get_mut(&state.heartbeat_from) else {
+            return;
+        };
+        // update peer
+        peer.last_seen = Instant::now();
+        self.merge_ban_list(state.ban_list);
+
         let current_time_in_sec = time_in_secs().unwrap();
         self.replication.ban_list.retain(|node| current_time_in_sec - node.ban_time < 60);
-
         if self.replication.ban_list.is_empty() {
             return;
         }

--- a/src/services/cluster/actors/actor.rs
+++ b/src/services/cluster/actors/actor.rs
@@ -1,7 +1,7 @@
 use crate::services::cluster::command::cluster_command::{AddPeer, ClusterCommand};
 use crate::services::cluster::peers::identifier::PeerIdentifier;
 use crate::services::cluster::peers::peer::Peer;
-use crate::services::cluster::replications::replication::{PeerState, Replication};
+use crate::services::cluster::replications::replication::{time_in_secs, PeerState, Replication};
 use crate::services::interface::TWrite;
 use crate::services::query_io::QueryIO;
 use std::collections::BTreeMap;
@@ -166,6 +166,10 @@ impl ClusterActor {
     }
 
     async fn cleanup_ban_list(&mut self) {
+        // TODO unwrap!
+        let current_time_in_sec = time_in_secs().unwrap();
+        self.replication.ban_list.retain(|node| current_time_in_sec - node.ban_time < 60);
+
         for node in
             self.replication.ban_list.iter().map(|node| node.p_id.clone()).collect::<Vec<_>>()
         {

--- a/src/services/cluster/replications/replication.rs
+++ b/src/services/cluster/replications/replication.rs
@@ -98,18 +98,6 @@ impl Replication {
         }
     }
 
-    // ! how do we remove peer from ban list when it comes from outside?
-    pub(crate) fn merge_ban_list(&mut self, ban_list: Vec<BannedPeer>) {
-        if ban_list.is_empty() {
-            return;
-        }
-
-        // merge, deduplicate and retain the latest
-        self.ban_list.extend(ban_list);
-        self.ban_list.sort_by_key(|node| (node.p_id.clone(), std::cmp::Reverse(node.ban_time)));
-        self.ban_list.dedup_by_key(|node| node.p_id.clone());
-    }
-
     pub(crate) fn ban_peer(&mut self, p_id: &PeerIdentifier) -> anyhow::Result<()> {
         self.ban_list.push(BannedPeer { p_id: p_id.clone(), ban_time: time_in_secs()? });
         Ok(())

--- a/src/services/cluster/replications/replication.rs
+++ b/src/services/cluster/replications/replication.rs
@@ -104,11 +104,8 @@ impl Replication {
             return;
         }
 
-        let current_time_in_sec = time_in_secs().unwrap();
-
         // merge, deduplicate and retain the latest
         self.ban_list.extend(ban_list);
-        self.ban_list.retain(|node| current_time_in_sec - node.ban_time < 60);
         self.ban_list.sort_by_key(|node| (node.p_id.clone(), std::cmp::Reverse(node.ban_time)));
         self.ban_list.dedup_by_key(|node| node.p_id.clone());
     }


### PR DESCRIPTION
while propagating ban_list, each node shoud:

1) register banned peer on the list
2) check on its ban_time - which doesn't require strong accuracy
3) remove the peer from its peer list
4) gossip that information 


This PR is for 3. and rest of them were done previously. 