### PR TITLE
fix: file save logic

### DIFF
--- a/src/services/client/manager.rs
+++ b/src/services/client/manager.rs
@@ -47,9 +47,15 @@ impl ClientManager {
                 self.cache_manager.route_set(cache_entry, self.ttl_manager.clone()).await?
             }
             ClientRequest::Save => {
+                let file_path = self.config_manager.get_filepath().await?;
+                let file = tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(&file_path)
+                    .await?;
                 self.cache_manager
                     .route_save(
-                        SaveTarget::File(self.config_manager.get_filepath().await?),
+                        SaveTarget::File(file),
                         self.cluster_manager.replication_info().await?,
                     )
                     .await?;

--- a/src/services/statefuls/snapshot/actor.rs
+++ b/src/services/statefuls/snapshot/actor.rs
@@ -38,7 +38,7 @@ impl SnapshotActor {
                             };
                             keys.push(key);
                         }
-                        println!("[INFO] Full Sync Keys: {:?}", keys);
+                        println!("[INFO] Snapshot Replaced with Keys: {:?}", keys);
                     }
                 }
             }

--- a/src/services/statefuls/snapshot/save/actor.rs
+++ b/src/services/statefuls/snapshot/save/actor.rs
@@ -17,23 +17,14 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
 pub enum SaveTarget {
-    File(String),
+    File(tokio::fs::File),
     InMemory(Vec<u8>),
 }
 
 impl SaveTarget {
     pub async fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
         match self {
-            SaveTarget::File(f) => {
-                let mut file = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(f)
-                    .await
-                    .map_err(|e| {
-                        println!("{e}");
-                        IoError::Unknown
-                    })?;
+            SaveTarget::File(file) => {
                 file.write_all(buf).await.map_err(|e| e.kind().into())
             }
             SaveTarget::InMemory(v) => {

--- a/tests/test_receive_full_sync.rs
+++ b/tests/test_receive_full_sync.rs
@@ -20,5 +20,5 @@ async fn test_receive_full_sync() {
 
     // THEN
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    replica_process.wait_for_message("[INFO] Full Sync Keys: [b\"foo\"]", 1).unwrap();
+    replica_process.wait_for_message("[INFO] Snapshot Replaced with Keys: [b\"foo\"]", 1).unwrap();
 }

--- a/tests/test_save_read_dump.rs
+++ b/tests/test_save_read_dump.rs
@@ -76,13 +76,19 @@ async fn test_save_read_dump() {
     let prev_master_repl_id = info[3].split(":").collect::<Vec<&str>>()[1];
     let prev_master_repl_offset = info[4].split(":").collect::<Vec<&str>>()[1];
 
-    // THEN
-
-    // THEN
     assert_eq!(h.send_and_get(&array(vec!["SAVE"])).await, QueryIO::Null.serialize());
 
     // wait for the file to be created
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // THEN
+    // kill master process
+    drop(master_process);
+
+    // run server with the same file name
+    let master_process = run_server_with_dbfilename(test_file_name.0.as_str());
+    let mut h = ClientStreamHandler::new(master_process.bind_addr()).await;
+
     // keys
     assert_eq!(h.send_and_get(&array(vec!["KEYS", "*"])).await, array(vec!["foo2", "foo"]));
 


### PR DESCRIPTION
This pull request includes the following changes:

- Fixed the save logic to ensure proper functionality.
- Refactored the code to change the save target to the itself to avoid.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #240 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #238 
- <kbd>&nbsp;1&nbsp;</kbd> #237 
<!-- GitButler Footer Boundary Bottom -->

