### PR TITLE
test: separate tests to prevent port collision

### DIFF
--- a/tests/test_cluster_forget_node_propagation.rs
+++ b/tests/test_cluster_forget_node_propagation.rs
@@ -1,31 +1,8 @@
-/// Cluster forget {node id} is used in order to remove a node, from the set of known nodes for the node receiving the command.
-/// In other words the specified node is removed from the nodes table of the node receiving the command.
 mod common;
 use common::{
     array, check_internodes_communication, spawn_server_as_follower, spawn_server_process,
 };
 use duva::client_utils::ClientStreamHandler;
-
-#[tokio::test]
-async fn test_cluster_forget_node_return_error_when_wrong_id_given() {
-    // GIVEN
-    let leader_p = spawn_server_process();
-
-    // WHEN
-    let mut client_handler = ClientStreamHandler::new(leader_p.bind_addr()).await;
-    let replica_id = "localhost:doesn't exist";
-    let cmd = &array(vec!["cluster", "forget", &replica_id]);
-    let cluster_info = client_handler.send_and_get(cmd).await;
-
-    // THEN
-    assert_eq!(cluster_info, "-No such peer\r\n");
-
-    // WHEN
-    let cluster_info = client_handler.send_and_get(&array(vec!["cluster", "info"])).await;
-
-    // THEN
-    assert_eq!(cluster_info, array(vec!["cluster_known_nodes:0"]));
-}
 
 #[tokio::test]
 async fn test_cluster_forget_node_propagation() {

--- a/tests/test_cluster_forget_when_wrong_id_given.rs
+++ b/tests/test_cluster_forget_when_wrong_id_given.rs
@@ -1,0 +1,26 @@
+/// Cluster forget {node id} is used in order to remove a node, from the set of known nodes for the node receiving the command.
+/// In other words the specified node is removed from the nodes table of the node receiving the command.
+mod common;
+use common::{array, spawn_server_process};
+use duva::client_utils::ClientStreamHandler;
+
+#[tokio::test]
+async fn test_cluster_forget_node_return_error_when_wrong_id_given() {
+    // GIVEN
+    let leader_p = spawn_server_process();
+
+    // WHEN
+    let mut client_handler = ClientStreamHandler::new(leader_p.bind_addr()).await;
+    let replica_id = "localhost:doesn't exist";
+    let cmd = &array(vec!["cluster", "forget", &replica_id]);
+    let cluster_info = client_handler.send_and_get(cmd).await;
+
+    // THEN
+    assert_eq!(cluster_info, "-No such peer\r\n");
+
+    // WHEN
+    let cluster_info = client_handler.send_and_get(&array(vec!["cluster", "info"])).await;
+
+    // THEN
+    assert_eq!(cluster_info, array(vec!["cluster_known_nodes:0"]));
+}


### PR DESCRIPTION
This PR aimed at mitigating the chances of port collision. 

Judging by how tests are run in integration tests, it seems tests in the same module runs together. 

If that's the case, it's highly likely that they causes port collision, leading to flakiness. 