### PR TITLE
enhancement: repl_id,repl_offset non optional

### DIFF
--- a/src/domains/saves/actor.rs
+++ b/src/domains/saves/actor.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::domains::{IoError, caches::cache_objects::CacheEntry};
+use crate::domains::{caches::cache_objects::CacheEntry, IoError};
 use tokio::io::AsyncWriteExt;
 
 use super::{
@@ -35,8 +35,7 @@ impl SaveActor {
             metadata.push(("repl-id", &self.meta.repl_id));
             metadata.push(("repl-offset", &self.meta.offset));
         }
-
-        let meta = [encode_header("0011")?, encode_metadata(metadata)?, encode_database_info(0)?];
+        let meta = [encode_header()?, encode_metadata(metadata)?, encode_database_info(0)?];
         self.target.write(&meta.concat()).await?;
         Ok(())
     }

--- a/src/domains/saves/actor.rs
+++ b/src/domains/saves/actor.rs
@@ -1,8 +1,5 @@
 use std::collections::VecDeque;
 
-use crate::domains::{caches::cache_objects::CacheEntry, IoError};
-use tokio::io::AsyncWriteExt;
-
 use super::{
     command::SaveCommand,
     endec::encoder::byte_encoder::{
@@ -10,6 +7,9 @@ use super::{
         encode_metadata,
     },
 };
+use crate::domains::saves::snapshot::snapshot::Metadata;
+use crate::domains::{caches::cache_objects::CacheEntry, IoError};
+use tokio::io::AsyncWriteExt;
 
 pub struct SaveActor {
     pub(crate) target: SaveTarget,
@@ -23,18 +23,14 @@ impl SaveActor {
         repl_id: String,
         current_offset: u64,
     ) -> anyhow::Result<Self> {
-        let meta = SaveMeta::new(num_of_shards, repl_id, current_offset.to_string());
+        let meta = SaveMeta::new(num_of_shards, repl_id, current_offset);
         let mut processor = Self { target, meta };
         processor.encode_meta().await?;
         Ok(processor)
     }
 
     pub async fn encode_meta(&mut self) -> anyhow::Result<()> {
-        let mut metadata: Vec<(&str, &str)> = vec![];
-        if &self.meta.repl_id != "?" {
-            metadata.push(("repl-id", &self.meta.repl_id));
-            metadata.push(("repl-offset", &self.meta.offset));
-        }
+        let metadata = Metadata { repl_id: self.meta.repl_id.clone(), repl_offset: self.meta.offset };
         let meta = [encode_header()?, encode_metadata(metadata)?, encode_database_info(0)?];
         self.target.write(&meta.concat()).await?;
         Ok(())
@@ -116,11 +112,11 @@ pub struct SaveMeta {
     pub(crate) chunk_queue: VecDeque<Vec<CacheEntry>>,
     pub(crate) num_of_cache_actors: usize,
     pub(crate) repl_id: String,
-    pub(crate) offset: String,
+    pub(crate) offset: u64,
 }
 
 impl SaveMeta {
-    pub fn new(num_of_cache_actors: usize, repl_id: String, offset: String) -> Self {
+    pub fn new(num_of_cache_actors: usize, repl_id: String, offset: u64) -> Self {
         Self {
             num_of_saved_table_size_actor: num_of_cache_actors,
             total_key_value_table_size: 0,

--- a/src/domains/saves/endec/decoder/byte_decoder.rs
+++ b/src/domains/saves/endec/decoder/byte_decoder.rs
@@ -29,8 +29,8 @@ pub(crate) struct DatabaseSectionBuilder {
 }
 
 impl DatabaseSectionBuilder {
-    pub fn build(self) -> DecodedDatabase {
-        DecodedDatabase { index: self.index, storage: self.storage }
+    pub fn build(self) -> SubDatabase {
+        SubDatabase { index: self.index, storage: self.storage }
     }
 }
 
@@ -139,8 +139,9 @@ impl<'a> BytesDecoder<'a, DecoderInit> {
     // read data and check first 5 ascii code convertable hex bytes are equal to "REDIS"
     // then read 4 digit Header version (like 0011) and return RdbFileLoader<MetadataSectionLoading> with header value as "REDIS" + 4 digit version
     pub fn load_header(mut self) -> Result<BytesDecoder<'a, HeaderReady>> {
-        if self.len() < 9 {
-            return Err(anyhow::Error::msg("header loading: data length is less than 9"))?;
+        let header_len = HEADER_MAGIC_STRING.len() + VERSION.len();
+        if self.len() < header_len {
+            return Err(anyhow::Error::msg(format!("header loading: data length is less than {}", header_len)))?;
         }
 
         let header = self.take_header()?;
@@ -149,9 +150,9 @@ impl<'a> BytesDecoder<'a, DecoderInit> {
         Ok(BytesDecoder { data: self.data, state: HeaderReady(format!("{}{}", header, version)) })
     }
     fn take_header(&mut self) -> Result<String> {
-        let header = self.take_string(5)?;
+        let header = self.take_string(HEADER_MAGIC_STRING.len())?;
         if header != HEADER_MAGIC_STRING {
-            return Err(anyhow::Error::msg("header loading: header is not REDIS"))?;
+            return Err(anyhow::Error::msg(format!("header loading: header is not {}", HEADER_MAGIC_STRING)))?;
         }
         Ok(header)
     }
@@ -209,7 +210,7 @@ impl BytesDecoder<'_, MetadataReady> {
             checksum,
         })
     }
-    fn extract_section(&mut self) -> Result<DecodedDatabase> {
+    fn extract_section(&mut self) -> Result<SubDatabase> {
         let mut builder: DatabaseSectionBuilder = DatabaseSectionBuilder::default();
 
         while let Some(identifier) = self.first() {
@@ -439,7 +440,7 @@ fn test_database_section_extractor() {
 
     let mut bytes_handler = BytesDecoder::<MetadataReady> { data, state: Default::default() };
 
-    let db_section: DecodedDatabase = bytes_handler.extract_section().unwrap();
+    let db_section: SubDatabase = bytes_handler.extract_section().unwrap();
     assert_eq!(db_section.index, 0);
     assert_eq!(db_section.storage.len(), 3);
 
@@ -527,12 +528,12 @@ fn test_invalid_expiry_key_value_pair() {
 #[test]
 fn test_header_loading() {
     let decoder = BytesDecoder::<DecoderInit> {
-        data: &[0x52, 0x45, 0x44, 0x49, 0x53, 0x30, 0x30, 0x30, 0x31],
+        data: &[HEADER_MAGIC_STRING.as_bytes(), VERSION.as_bytes()].concat(),
         state: Default::default(),
     };
     let header = decoder.load_header().unwrap();
 
-    assert_eq!(header.state, HeaderReady("REDIS0001".to_string()));
+    assert_eq!(header.state, HeaderReady(HEADER_MAGIC_STRING.to_string() + VERSION));
 }
 
 #[test]
@@ -584,9 +585,12 @@ fn test_loading_all() {
     const R_ID_SIZE: u8 = 0x28;
     const D_KEY: u8 = 0xFE;
 
-    let data = vec![
-        // Header
-        0x52, 0x45, 0x44, 0x49, 0x53, 0x30, 0x30, 0x31, 0x31, // Metadata
+    let mut data = Vec::new();
+    data.extend_from_slice(HEADER_MAGIC_STRING.as_bytes());
+    data.extend_from_slice(VERSION.as_bytes());
+
+    data.extend_from_slice(&[
+        // Metadata
         //* repl-id
         M_KEY, 0x07, //size of key
         0x72, 0x65, 0x70, 0x6c, 0x2d, 0x69, 0x64, R_ID_SIZE, // size of value(hex 28 = 40)
@@ -600,14 +604,14 @@ fn test_loading_all() {
         D_KEY, 0x00, 0xFB, 0x02, 0x00, 0x00, 0x04, 0x66, 0x6F, 0x6F, 0x32, 0x04, 0x62, 0x61, 0x72,
         0x32, 0x00, 0x03, 0x66, 0x6F, 0x6F, 0x03, 0x62, 0x61, 0x72, 0xFF, 0x60, 0x82, 0x9C, 0xF8,
         0xFB, 0x2E, 0x7F, 0xEB,
-    ];
+    ]);
     let bytes_handler =
         BytesDecoder::<DecoderInit> { data: data.as_slice().into(), state: Default::default() };
 
     let rdb_file =
         bytes_handler.load_header().unwrap().load_metadata().unwrap().load_database().unwrap();
 
-    assert_eq!(rdb_file.header, "REDIS0011");
+    assert_eq!(rdb_file.header, HEADER_MAGIC_STRING.to_string() + VERSION);
     assert_eq!(rdb_file.database.len(), 1);
     assert_eq!(rdb_file.database[0].index, 0);
     assert_eq!(rdb_file.database[0].storage.len(), 2);

--- a/src/domains/saves/endec/decoder/states.rs
+++ b/src/domains/saves/endec/decoder/states.rs
@@ -1,4 +1,4 @@
-use crate::domains::saves::snapshot::snapshot::DecodedMetadata;
+use crate::domains::saves::snapshot::snapshot::Metadata;
 
 #[derive(Default)]
 pub struct DecoderInit;
@@ -7,6 +7,6 @@ pub struct DecoderInit;
 pub struct HeaderReady(pub(crate) String);
 #[derive(Default)]
 pub struct MetadataReady {
-    pub(crate) metadata: DecodedMetadata,
+    pub(crate) metadata: Metadata,
     pub(crate) header: String,
 }

--- a/src/domains/saves/endec/encoder/byte_encoder.rs
+++ b/src/domains/saves/endec/encoder/byte_encoder.rs
@@ -7,6 +7,7 @@ use crate::domains::{
     },
 };
 
+use crate::domains::saves::endec::VERSION;
 use anyhow::Result;
 use std::time::UNIX_EPOCH;
 
@@ -31,13 +32,10 @@ impl CacheEntry {
     }
 }
 
-pub fn encode_header(version: &str) -> Result<Vec<u8>> {
-    if version.len() != 4 {
-        return Err(anyhow::anyhow!("Invalid version string"));
-    }
+pub fn encode_header() -> Result<Vec<u8>> {
     let mut result = Vec::new();
     result.extend_from_slice(HEADER_MAGIC_STRING.as_bytes());
-    result.extend_from_slice(version.as_bytes());
+    result.extend_from_slice(VERSION.as_bytes());
     Ok(result)
 }
 
@@ -130,8 +128,8 @@ fn encode_size(size: usize) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod test {
     use crate::domains::saves::endec::{
-        StoredDuration,
         decoder::{byte_decoder::BytesDecoder, states::DecoderInit},
+        StoredDuration,
     };
 
     use super::*;
@@ -340,10 +338,9 @@ mod test {
 
     #[test]
     fn test_encode_header() {
-        let version = "0001";
-        let encoded = encode_header(version).unwrap();
-        let expected = vec![0x52, 0x45, 0x44, 0x49, 0x53, 0x30, 0x30, 0x30, 0x31];
-        assert_eq!(encoded, expected);
+        let encoded = encode_header().unwrap();
+        let header = HEADER_MAGIC_STRING.to_string() + VERSION;
+        assert_eq!(encoded, header.as_bytes());
     }
 
     #[test]

--- a/src/domains/saves/endec/encoder/byte_encoder.rs
+++ b/src/domains/saves/endec/encoder/byte_encoder.rs
@@ -8,6 +8,7 @@ use crate::domains::{
 };
 
 use crate::domains::saves::endec::VERSION;
+use crate::domains::saves::snapshot::snapshot::Metadata;
 use anyhow::Result;
 use std::time::UNIX_EPOCH;
 
@@ -39,12 +40,12 @@ pub fn encode_header() -> Result<Vec<u8>> {
     Ok(result)
 }
 
-pub fn encode_metadata(metadata: Vec<(&str, &str)>) -> Result<Vec<u8>> {
+pub fn encode_metadata(metadata: Metadata) -> Result<Vec<u8>> {
     let mut result = Vec::new();
-    for (key, value) in metadata.iter() {
-        result.push(METADATA_SECTION_INDICATOR);
-        result.extend_from_slice(&encode_key_value(key, value)?);
-    }
+    result.push(METADATA_SECTION_INDICATOR);
+    result.extend_from_slice(&encode_key_value("repl-id", &metadata.repl_id)?);
+    result.push(METADATA_SECTION_INDICATOR);
+    result.extend_from_slice(&encode_key_value("repl-offset", &metadata.repl_offset.to_string())?);
     Ok(result)
 }
 pub fn encode_database_info(index: usize) -> Result<Vec<u8>> {
@@ -345,37 +346,41 @@ mod test {
 
     #[test]
     fn test_encode_metadata() {
-        let mut metadata = Vec::new();
-        metadata.push(("key1", "value1"));
-        metadata.push(("key2", "value2"));
+        let metadata = Metadata {
+            repl_id: "key1".to_string(),
+            repl_offset: 123,
+        };
         let encoded = encode_metadata(metadata).unwrap();
         let expected = vec![
             METADATA_SECTION_INDICATOR,
+            0x07,
+            b'r',
+            b'e',
+            b'p',
+            b'l',
+            b'-',
+            b'i',
+            b'd',
             0x04,
             b'k',
             b'e',
             b'y',
-            b'1',
-            0x06,
-            b'v',
-            b'a',
-            b'l',
-            b'u',
-            b'e',
             b'1',
             METADATA_SECTION_INDICATOR,
-            0x04,
-            b'k',
+            0x0B,
+            b'r',
             b'e',
-            b'y',
-            b'2',
-            0x06,
-            b'v',
-            b'a',
+            b'p',
             b'l',
-            b'u',
+            b'-',
+            b'o',
+            b'f',
+            b'f',
+            b's',
             b'e',
-            b'2',
+            b't',
+            192,
+            123
         ];
         assert_eq!(encoded, expected);
     }

--- a/src/domains/saves/endec/mod.rs
+++ b/src/domains/saves/endec/mod.rs
@@ -76,10 +76,12 @@
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
 
+
 pub mod decoder;
 pub mod encoder;
 
-const HEADER_MAGIC_STRING: &str = "REDIS";
+const HEADER_MAGIC_STRING: &str = "DUVA";
+const VERSION: &str = "0001";
 const METADATA_SECTION_INDICATOR: u8 = 0xFA;
 const DATABASE_SECTION_INDICATOR: u8 = 0xFE;
 const DATABASE_TABLE_SIZE_INDICATOR: u8 = 0xFB;

--- a/src/domains/saves/snapshot/snapshot.rs
+++ b/src/domains/saves/snapshot/snapshot.rs
@@ -3,16 +3,16 @@ use crate::domains::caches::cache_objects::CacheEntry;
 #[derive(Debug)]
 pub struct Snapshot {
     pub(crate) header: String,
-    pub(crate) metadata: DecodedMetadata,
-    pub(crate) database: Vec<DecodedDatabase>,
+    pub(crate) metadata: Metadata,
+    pub(crate) database: Vec<SubDatabase>,
     pub(crate) checksum: Vec<u8>,
 }
 
 impl Snapshot {
     pub fn new(
         header: String,
-        metadata: DecodedMetadata,
-        database: Vec<DecodedDatabase>,
+        metadata: Metadata,
+        database: Vec<SubDatabase>,
         checksum: Vec<u8>,
     ) -> Self {
         Self { header, metadata, database, checksum }
@@ -21,23 +21,19 @@ impl Snapshot {
         self.database.into_iter().flat_map(|section| section.storage.into_iter()).collect()
     }
 
-    pub fn extract_replication_info(&self) -> Option<(String, u64)> {
-        match (self.metadata.repl_id.as_ref(), self.metadata.repl_offset) {
-            (Some(repl_id), Some(offset)) => Some((repl_id.clone(), offset)),
-            _ => None,
-        }
+    pub fn extract_replication_info(&self) -> (String, u64) {
+        (self.metadata.repl_id.clone(), self.metadata.repl_offset)
     }
 }
 
-// TODO make it non-nullable?
 #[derive(Debug, Default, PartialEq)]
-pub struct DecodedMetadata {
-    pub(crate) repl_id: Option<String>,
-    pub(crate) repl_offset: Option<u64>,
+pub struct Metadata {
+    pub(crate) repl_id: String,
+    pub(crate) repl_offset: u64,
 }
 
 #[derive(Debug)]
-pub struct DecodedDatabase {
+pub struct SubDatabase {
     pub index: usize,
     pub storage: Vec<CacheEntry>,
 }


### PR DESCRIPTION
**Changes Made:**
- Now Header Name is `DUVA` and Version Name is `0001`
- Updated the implementation to enforce the requirement for `repl_id` and `repl_offset`, ensuring they are mandatory fields.