### PR TITLE
test-fix: port collision 

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -81,15 +81,15 @@ impl TestProcessChild {
     pub fn terminate(&mut self) -> std::io::Result<()> {
         // First try graceful shutdown
         // Give the process some time to shutdown gracefully
-        // let timeout = Duration::from_secs(2);
-        // let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(1);
+        let start = std::time::Instant::now();
 
-        // while start.elapsed() < timeout {
-        //     match self.process.try_wait()? {
-        //         Some(_) => return Ok(()),
-        //         None => thread::sleep(Duration::from_millis(100)),
-        //     }
-        // }
+        while start.elapsed() < timeout {
+            match self.process.try_wait()? {
+                Some(_) => return Ok(()),
+                None => thread::sleep(Duration::from_millis(100)),
+            }
+        }
 
         // Force kill if still running
         self.process.kill()?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,14 +2,18 @@ use bytes::Bytes;
 use duva::domains::query_parsers::query_io::QueryIO;
 use duva::make_smart_pointer;
 use std::io::{BufRead, BufReader, Read};
+use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
 use std::thread::{self};
 use std::time::{Duration, Instant};
 
-static PORT_DISTRIBUTOR: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(49152);
-
+// Let the OS assign a free port dynamically to reduce port conflicts:
 pub fn get_available_port() -> u16 {
-    PORT_DISTRIBUTOR.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to bind to a random port")
+        .local_addr()
+        .unwrap()
+        .port()
 }
 
 pub fn spawn_server_process() -> TestProcessChild {
@@ -77,26 +81,21 @@ impl TestProcessChild {
     pub fn terminate(&mut self) -> std::io::Result<()> {
         // First try graceful shutdown
         // Give the process some time to shutdown gracefully
-        let timeout = Duration::from_secs(2);
-        let start = std::time::Instant::now();
+        // let timeout = Duration::from_secs(2);
+        // let start = std::time::Instant::now();
 
-        while start.elapsed() < timeout {
-            match self.process.try_wait()? {
-                Some(_) => return Ok(()),
-                None => thread::sleep(Duration::from_millis(100)),
-            }
-        }
+        // while start.elapsed() < timeout {
+        //     match self.process.try_wait()? {
+        //         Some(_) => return Ok(()),
+        //         None => thread::sleep(Duration::from_millis(100)),
+        //     }
+        // }
 
         // Force kill if still running
         self.process.kill()?;
         self.process.wait()?;
 
         Ok(())
-    }
-
-    /// Checks if the process is still running
-    pub fn is_running(&mut self) -> bool {
-        self.process.try_wait().map(|status| status.is_none()).unwrap_or(false)
     }
 
     pub fn wait_for_message(&mut self, target: &str, target_count: usize) -> anyhow::Result<()> {

--- a/tests/test_replication_info.rs
+++ b/tests/test_replication_info.rs
@@ -31,5 +31,5 @@ async fn test_replication_info() {
     assert_eq!(info[6], "repl_backlog_active:0");
     assert_eq!(info[7], "repl_backlog_size:1048576");
     assert_eq!(info[8], "repl_backlog_first_byte_offset:0");
-    assert_eq!(info[9], "self_identifier:127.0.0.1:49152");
+    assert_eq!(info[9], format!("self_identifier:127.0.0.1:{}", process.port()));
 }


### PR DESCRIPTION
Current Global value distribution didn't work as integration tests run sequentially unless there are not in the same module.

Instead of handling this, this PR fixed the code so OS can dynamically allocate the port. 