### PR TITLE
fix: replace new follower's repl id from leader side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ rp ?= 6378
 NETCAT = nc 127.0.0.1 $(p)
 k = foo
 v = bar
+tp = duva.tp
 
 define send_command
 	( printf $1 | $(NETCAT) )
@@ -41,7 +42,21 @@ leader:
 	@echo '🚀 Starting leader node in local_test/leader...'
 	@cd local_test/leader && cargo run -- --port $(p)
 
+leader-tp:
+	@mkdir -p local_test/leader
+	@cd local_test/leader && cargo run -- --port $(p) --topology_path $(tp)
+
+leader-aof:
+	@echo '🔧 Setting up replication with leader on port $(p) and follower on port $(rp)...'
+	@mkdir -p local_test/leader
+	@echo '🚀 Starting leader node in local_test/leader...'
+	@cd local_test/leader && cargo run -- --port $(p) --append_only true
+
 follower:
 	@echo '🚀 Starting follower node in local_test/follower...'
 	@mkdir -p local_test/follower
 	@cd local_test/follower && cargo run -- --port $(rp) --replicaof 127.0.0.1:$(p)
+
+follower-tp:
+	@mkdir -p local_test/follower
+	@cd local_test/follower && cargo run -- --port $(rp) --replicaof 127.0.0.1:$(p) --topology_path $(tp)

--- a/src/domains/peers/peer.rs
+++ b/src/domains/peers/peer.rs
@@ -1,8 +1,8 @@
 use super::connected_peer_info::ConnectedPeerInfo;
-use crate::domains::IoError;
 use crate::domains::cluster_actors::replication::ReplicationId;
 use crate::domains::peers::connected_types::WriteConnected;
 use crate::domains::query_parsers::QueryIO;
+use crate::domains::IoError;
 use crate::services::interface::TWrite;
 
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -52,7 +52,7 @@ pub enum PeerState {
 impl PeerState {
     pub fn decide_peer_kind(my_repl_id: &ReplicationId, peer_info: &ConnectedPeerInfo) -> Self {
         if peer_info.replid == ReplicationId::Undecided {
-            PeerState::Replica { match_index: peer_info.hwm, replid: peer_info.replid.clone() }
+            PeerState::Replica { match_index: peer_info.hwm, replid: my_repl_id.clone() }
         } else if my_repl_id == &peer_info.replid {
             PeerState::Replica { match_index: peer_info.hwm, replid: peer_info.replid.clone() }
         } else {

--- a/src/domains/peers/peer.rs
+++ b/src/domains/peers/peer.rs
@@ -1,8 +1,8 @@
 use super::connected_peer_info::ConnectedPeerInfo;
+use crate::domains::IoError;
 use crate::domains::cluster_actors::replication::ReplicationId;
 use crate::domains::peers::connected_types::WriteConnected;
 use crate::domains::query_parsers::QueryIO;
-use crate::domains::IoError;
 use crate::services::interface::TWrite;
 
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};

--- a/src/init.rs
+++ b/src/init.rs
@@ -26,7 +26,7 @@ impl Environment {
                 hf = 1000,
                 ttl = 60000,
                 append_only = false,
-                topology_path = "duva.tp".to_string()
+                tpp = "duva.tp".to_string() // topology path
             }
         );
         let replicaof = replicaof.map(|host_port| {
@@ -46,7 +46,7 @@ impl Environment {
             hf_mills: hf,
             ttl_mills: ttl,
             append_only,
-            topology_path,
+            topology_path: tpp,
         }
     }
 }

--- a/src/presentation/clusters/connection_manager.rs
+++ b/src/presentation/clusters/connection_manager.rs
@@ -3,7 +3,7 @@ use super::outbound::stream::OutboundStream;
 
 use crate::domains::cluster_actors::commands::ClusterCommand;
 use crate::domains::peers::identifier::PeerIdentifier;
-use crate::{make_smart_pointer, InboundStream};
+use crate::{InboundStream, make_smart_pointer};
 use tokio::sync::mpsc::Sender;
 
 pub struct ClusterConnectionManager(pub(crate) ClusterCommunicationManager);

--- a/src/presentation/clusters/connection_manager.rs
+++ b/src/presentation/clusters/connection_manager.rs
@@ -3,7 +3,7 @@ use super::outbound::stream::OutboundStream;
 
 use crate::domains::cluster_actors::commands::ClusterCommand;
 use crate::domains::peers::identifier::PeerIdentifier;
-use crate::{InboundStream, make_smart_pointer};
+use crate::{make_smart_pointer, InboundStream};
 use tokio::sync::mpsc::Sender;
 
 pub struct ClusterConnectionManager(pub(crate) ClusterCommunicationManager);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -193,6 +193,8 @@ pub fn run_server_process(env: &ServerEnv) -> TestProcessChild {
         &env.ttl.to_string(),
         "--use_wal",
         &env.use_wal.to_string(),
+        "--tpp",
+        &env.topology_path.0.as_ref().unwrap_or(&"duva.tp".to_string()),
     ]);
 
     if let Some(replicaof) = env.leader_bind_addr.as_ref() {

--- a/tests/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
+++ b/tests/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
@@ -1,17 +1,17 @@
 mod common;
-use common::{ServerEnv, array, spawn_server_process};
+use common::{array, spawn_server_process, ServerEnv};
 use duva::client_utils::ClientStreamHandler;
 
 #[tokio::test]
-async fn test_cluster_known_nodes_increase_when_new_replica_is_added() {
+async fn test_cluster_topology_change_when_new_node_added() {
     // GIVEN
-    let env = ServerEnv::default();
+    let env = ServerEnv::default().with_topology_path("test_leader.tp");
     let mut leader_p = spawn_server_process(&env);
     let mut client_handler = ClientStreamHandler::new(leader_p.bind_addr()).await;
 
     let cmd = &array(vec!["cluster", "info"]);
 
-    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into());
+    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()).with_topology_path("test_repl.tp");
     let mut repl_p = spawn_server_process(&repl_env);
     repl_p.wait_for_message(&leader_p.heartbeat_msg(0), 1).unwrap();
     leader_p.wait_for_message(&repl_p.heartbeat_msg(0), 1).unwrap();
@@ -20,7 +20,7 @@ async fn test_cluster_known_nodes_increase_when_new_replica_is_added() {
     assert_eq!(cluster_info, array(vec!["cluster_known_nodes:1"]));
 
     // WHEN -- new replica is added
-    let repl_env2 = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into());
+    let repl_env2 = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()).with_topology_path("test_repl2.tp");
     let mut new_repl_p = spawn_server_process(&repl_env2);
     new_repl_p.wait_for_message(&leader_p.heartbeat_msg(0), 1).unwrap();
 
@@ -30,4 +30,18 @@ async fn test_cluster_known_nodes_increase_when_new_replica_is_added() {
     // right: b"*1\r\n$21\r\ncluster_known_nodes:2\r\n"
     let cluster_info = client_handler.send_and_get(cmd).await;
     assert_eq!(cluster_info, array(vec!["cluster_known_nodes:2"]));
+
+    let mut nodes = Vec::new();
+   client_handler.send_and_get(&array(vec!["cluster","nodes"])).await.lines().for_each(|line| nodes.push(line.to_string()));
+
+    let mut leader_nodes = Vec::new();
+    tokio::fs::read_to_string("test_leader.tp")
+        .await
+        .unwrap()
+        .lines()
+        .for_each(|line| leader_nodes.push(line.to_string()));
+
+    for node in leader_nodes {
+        assert!(nodes.contains(&node));
+    }
 }

--- a/tests/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
+++ b/tests/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{array, spawn_server_process, ServerEnv};
+use common::{ServerEnv, array, spawn_server_process};
 use duva::client_utils::ClientStreamHandler;
 
 #[tokio::test]
@@ -11,7 +11,9 @@ async fn test_cluster_topology_change_when_new_node_added() {
 
     let cmd = &array(vec!["cluster", "info"]);
 
-    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()).with_topology_path("test_repl.tp");
+    let repl_env = ServerEnv::default()
+        .with_leader_bind_addr(leader_p.bind_addr().into())
+        .with_topology_path("test_repl.tp");
     let mut repl_p = spawn_server_process(&repl_env);
     repl_p.wait_for_message(&leader_p.heartbeat_msg(0), 1).unwrap();
     leader_p.wait_for_message(&repl_p.heartbeat_msg(0), 1).unwrap();
@@ -20,7 +22,9 @@ async fn test_cluster_topology_change_when_new_node_added() {
     assert_eq!(cluster_info, array(vec!["cluster_known_nodes:1"]));
 
     // WHEN -- new replica is added
-    let repl_env2 = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()).with_topology_path("test_repl2.tp");
+    let repl_env2 = ServerEnv::default()
+        .with_leader_bind_addr(leader_p.bind_addr().into())
+        .with_topology_path("test_repl2.tp");
     let mut new_repl_p = spawn_server_process(&repl_env2);
     new_repl_p.wait_for_message(&leader_p.heartbeat_msg(0), 1).unwrap();
 
@@ -32,7 +36,11 @@ async fn test_cluster_topology_change_when_new_node_added() {
     assert_eq!(cluster_info, array(vec!["cluster_known_nodes:2"]));
 
     let mut nodes = Vec::new();
-   client_handler.send_and_get(&array(vec!["cluster","nodes"])).await.lines().for_each(|line| nodes.push(line.to_string()));
+    client_handler
+        .send_and_get(&array(vec!["cluster", "nodes"]))
+        .await
+        .lines()
+        .for_each(|line| nodes.push(line.to_string()));
 
     let mut leader_nodes = Vec::new();
     tokio::fs::read_to_string("test_leader.tp")


### PR DESCRIPTION
### Pull Request Description

This pull request includes the following changes:

- Added a Makefile for build automation.
- Fixed the issue of replacing peers' replid during the first connection.
- Added tests for topology changes.