### PR TITLE
test: set twice after election

### DIFF
--- a/duva/tests/test_leader_election.rs
+++ b/duva/tests/test_leader_election.rs
@@ -36,6 +36,42 @@ async fn test_leader_election() {
     assert!([response1, response2].iter().any(|d| d.contains("role:leader")));
 }
 
+// ! EDGE case : when last_log_term is not updated, after the election, first write operation succeeds but second one doesn't
+// ! This is because the leader doesn't have the last_log_term of the first write operation
+// ! This test is to see if the leader can set the value twice after the election
+#[tokio::test]
+async fn test_set_twice_after_election() {
+    // GIVEN
+    let mut leader_p = spawn_server_process(&ServerEnv::default());
+
+    let mut follower_p1 = spawn_server_process(
+        &ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()),
+    );
+
+    let mut follower_p2 = spawn_server_process(
+        &ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into()),
+    );
+    const DEFAULT_HOP_COUNT: usize = 0;
+    const TIMEOUT_IN_MILLIS: u128 = 2000;
+    let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
+    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).unwrap();
+
+    // WHEN
+    leader_p.kill().unwrap();
+    sleep(Duration::from_secs(1));
+    let mut handler = ClientStreamHandler::new(follower_p1.bind_addr()).await;
+    let mut handler2 = ClientStreamHandler::new(follower_p2.bind_addr()).await;
+    let response1 = handler.send_and_get(&array(vec!["info", "replication"])).await;
+
+    if response1.contains("role:leader") {
+        let _ = handler.send_and_get(&array(vec!["set", "1", "2"])).await;
+        let _ = handler.send_and_get(&array(vec!["set", "2", "3"])).await;
+    } else {
+        let _ = handler2.send_and_get(&array(vec!["set", "1", "2"])).await;
+        let _ = handler2.send_and_get(&array(vec!["set", "2", "3"])).await;
+    };
+}
+
 /// following test is to see if election works even after the first election.
 #[tokio::test]
 async fn test_leader_election_twice() {


### PR DESCRIPTION
closed #430 


There was a bug where after election, write operation after the first one failed. 

Although bug was fixed with the previous [PR](https://github.com/Migorithm/duva/pull/430)

There is no test for this; therefore this PR. 