### PR TITLE
feat: pull-based reconnection to new leader instance

### DIFF
--- a/duva-client/src/cli/main.rs
+++ b/duva-client/src/cli/main.rs
@@ -32,7 +32,8 @@ async fn main() {
 
         match take_input(cmd, &args) {
             Ok(input) => {
-                if let Err(e) = controller.send_command(cmd, args, input).await {
+                let command = controller.build_command(cmd, args);
+                if let Err(e) = controller.send_command(command, input).await {
                     println!("{}", e);
                 }
             },

--- a/duva-client/src/command.rs
+++ b/duva-client/src/command.rs
@@ -6,17 +6,6 @@ pub fn separate_command_and_args(args: Vec<&str>) -> (&str, Vec<&str>) {
     (cmd, args)
 }
 
-pub(crate) fn build_command(cmd: &str, args: Vec<&str>, request_id: u64) -> String {
-    // Build the valid RESP command
-    let mut command =
-        format!("!{}\r\n*{}\r\n${}\r\n{}\r\n", request_id, args.len() + 1, cmd.len(), cmd);
-    for arg in args {
-        command.push_str(&format!("${}\r\n{}\r\n", arg.len(), arg));
-    }
-
-    command
-}
-
 pub fn take_input(action: &str, args: &[&str]) -> Result<ClientInputKind, String> {
     // Check for invalid characters in command parts
     // Command-specific validation

--- a/duva-client/src/controller.rs
+++ b/duva-client/src/controller.rs
@@ -41,6 +41,9 @@ impl<T> ClientController<T> {
     // pull-based leader discovery
     async fn discover_leader(&mut self) -> Result<(), String> {
         for node in &self.cluster_nodes {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            println!("Trying to connect to node: {}...", node);
+
             let Ok(mut stream) = TcpStream::connect(node.as_str()).await else {
                 continue;
             };

--- a/duva-client/src/controller.rs
+++ b/duva-client/src/controller.rs
@@ -38,6 +38,7 @@ impl<T> ClientController<T> {
         }
     }
 
+    // pull-based leader discovery
     async fn discover_leader(&mut self) -> Result<(), String> {
         for node in &self.cluster_nodes {
             let Ok(mut stream) = TcpStream::connect(node.as_str()).await else {
@@ -60,7 +61,7 @@ impl<T> ClientController<T> {
                 return Ok(());
             }
         }
-        Err("No leader found".to_string())
+        Err("No leader found in the cluster".to_string())
     }
 
     async fn authenticate(server_addr: &str) -> (TcpStream, AuthResponse) {

--- a/duva/src/clients/authentications.rs
+++ b/duva/src/clients/authentications.rs
@@ -1,3 +1,5 @@
+use crate::domains::peers::identifier::PeerIdentifier;
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, bincode::Decode, bincode::Encode)]
 pub struct AuthRequest {
     pub client_id: Option<String>,
@@ -7,4 +9,5 @@ pub struct AuthRequest {
 pub struct AuthResponse {
     pub client_id: String,
     pub request_id: u64,
+    pub cluster_nodes: Vec<PeerIdentifier>,
 }

--- a/duva/src/clients/authentications.rs
+++ b/duva/src/clients/authentications.rs
@@ -3,6 +3,7 @@ use crate::domains::peers::identifier::PeerIdentifier;
 #[derive(Debug, Clone, PartialEq, Eq, Default, bincode::Decode, bincode::Encode)]
 pub struct AuthRequest {
     pub client_id: Option<String>,
+    pub request_id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, bincode::Decode, bincode::Encode)]
@@ -10,4 +11,5 @@ pub struct AuthResponse {
     pub client_id: String,
     pub request_id: u64,
     pub cluster_nodes: Vec<PeerIdentifier>,
+    pub connected_to_leader: bool,
 }

--- a/duva/src/clients/utils.rs
+++ b/duva/src/clients/utils.rs
@@ -34,7 +34,7 @@ impl ClientStreamHandler {
 
         stream.serialized_write(AuthRequest::default()).await.unwrap(); // client_id not exist
 
-        let AuthResponse { client_id, request_id, cluster_nodes } =
+        let AuthResponse { client_id, request_id, cluster_nodes, connected_to_leader } =
             stream.deserialized_read().await.unwrap();
         let client_id = Uuid::parse_str(&client_id).unwrap();
 

--- a/duva/src/clients/utils.rs
+++ b/duva/src/clients/utils.rs
@@ -34,7 +34,8 @@ impl ClientStreamHandler {
 
         stream.serialized_write(AuthRequest::default()).await.unwrap(); // client_id not exist
 
-        let AuthResponse { client_id, request_id } = stream.deserialized_read().await.unwrap();
+        let AuthResponse { client_id, request_id, cluster_nodes } =
+            stream.deserialized_read().await.unwrap();
         let client_id = Uuid::parse_str(&client_id).unwrap();
 
         let (read_half, write_half) = stream.into_split();

--- a/duva/src/domains/peers/identifier.rs
+++ b/duva/src/domains/peers/identifier.rs
@@ -3,7 +3,7 @@ use crate::{from_to, make_smart_pointer};
 #[derive(
     Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Default, bincode::Encode, bincode::Decode,
 )]
-pub(crate) struct PeerIdentifier(pub String);
+pub struct PeerIdentifier(pub String);
 impl PeerIdentifier {
     pub(crate) fn new(host: &str, port: u16) -> Self {
         Self(format!("{}:{}", host, port))

--- a/duva/src/domains/peers/mod.rs
+++ b/duva/src/domains/peers/mod.rs
@@ -1,5 +1,5 @@
 pub mod connected_peer_info;
 pub(crate) mod connected_types;
-pub(crate) mod identifier;
+pub mod identifier;
 
 pub(crate) mod peer;

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -132,7 +132,16 @@ impl StartUpFacade {
 
         while let Ok((stream, _)) = client_stream_listener.accept().await {
             let peers = self.registry.cluster_communication_manager().get_peers().await?;
-            let Ok(client_stream) = ClientStream::authenticate(stream, peers).await else {
+
+            // TODO implement ROLE command
+            let is_leader = self
+                .registry
+                .cluster_communication_manager()
+                .replication_info()
+                .await?
+                .is_leader_mode;
+            let Ok(client_stream) = ClientStream::authenticate(stream, peers, is_leader).await
+            else {
                 eprintln!("[ERROR] Failed to authenticate client stream");
                 continue;
             };

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -23,6 +23,7 @@ use services::interface::TSerdeReadWrite;
 use tokio::net::TcpListener;
 
 pub mod prelude {
+    pub use crate::domains::peers::identifier::PeerIdentifier;
     pub use bytes;
     pub use bytes::BytesMut;
     pub use tokio;
@@ -128,8 +129,10 @@ impl StartUpFacade {
         let client_stream_listener = TcpListener::bind(&self.config_manager.bind_addr()).await?;
         println!("start listening on {}", self.config_manager.bind_addr());
         let mut conn_handlers: Vec<tokio::task::JoinHandle<()>> = Vec::with_capacity(100);
+
         while let Ok((stream, _)) = client_stream_listener.accept().await {
-            let Ok(client_stream) = ClientStream::authenticate(stream).await else {
+            let peers = self.registry.cluster_communication_manager().get_peers().await?;
+            let Ok(client_stream) = ClientStream::authenticate(stream, peers).await else {
                 eprintln!("[ERROR] Failed to authenticate client stream");
                 continue;
             };

--- a/duva/src/presentation/clients/stream.rs
+++ b/duva/src/presentation/clients/stream.rs
@@ -24,6 +24,7 @@ impl ClientStream {
     pub(crate) async fn authenticate(
         mut stream: TcpStream,
         peers: Vec<PeerIdentifier>,
+        is_leader: bool,
     ) -> Result<Self, IoError> {
         let auth_req: AuthRequest = stream.deserialized_read().await?;
 
@@ -38,8 +39,9 @@ impl ClientStream {
         stream
             .serialized_write(AuthResponse {
                 client_id: client_id.to_string(),
-                request_id: 0,
+                request_id: auth_req.request_id,
                 cluster_nodes: peers,
+                connected_to_leader: is_leader,
             })
             .await?;
 

--- a/duva/src/presentation/clients/stream.rs
+++ b/duva/src/presentation/clients/stream.rs
@@ -2,7 +2,10 @@ use super::{parser::parse_query, request::ClientRequest};
 use crate::{
     TSerdeReadWrite,
     clients::authentications::{AuthRequest, AuthResponse},
-    domains::{IoError, cluster_actors::session::SessionRequest, query_parsers::QueryIO},
+    domains::{
+        IoError, cluster_actors::session::SessionRequest, peers::identifier::PeerIdentifier,
+        query_parsers::QueryIO,
+    },
     make_smart_pointer,
     services::interface::TRead,
 };
@@ -18,7 +21,10 @@ pub struct ClientStream {
 make_smart_pointer!(ClientStream, TcpStream=>stream);
 
 impl ClientStream {
-    pub(crate) async fn authenticate(mut stream: TcpStream) -> Result<Self, IoError> {
+    pub(crate) async fn authenticate(
+        mut stream: TcpStream,
+        peers: Vec<PeerIdentifier>,
+    ) -> Result<Self, IoError> {
         let auth_req: AuthRequest = stream.deserialized_read().await?;
 
         let client_id = match auth_req.client_id {
@@ -30,7 +36,11 @@ impl ClientStream {
         };
 
         stream
-            .serialized_write(AuthResponse { client_id: client_id.to_string(), request_id: 0 })
+            .serialized_write(AuthResponse {
+                client_id: client_id.to_string(),
+                request_id: 0,
+                cluster_nodes: peers,
+            })
             .await?;
 
         Ok(Self { stream, client_id })


### PR DESCRIPTION
basic implementation for  #427 

backlogs : reseeding cluster nodes on add_peer from leader to all the connected clients 