### PR TITLE
feat: Allow new nodes to join cluster via follower addresses

### DIFF
--- a/duva/src/domains/cluster_actors/commands/mod.rs
+++ b/duva/src/domains/cluster_actors/commands/mod.rs
@@ -2,7 +2,7 @@ mod election;
 pub(crate) mod types;
 mod write_con;
 use super::{
-    replication::{HeartBeatMessage, ReplicationId, ReplicationState},
+    replication::{HeartBeatMessage, ReplicationId, ReplicationState, Role},
     session::SessionRequest,
 };
 use crate::domains::append_only_files::WriteOperation;
@@ -44,7 +44,7 @@ pub(crate) enum ClusterCommand {
     VoteElection(RequestVote),
     ApplyElectionVote(RequestVoteReply),
     ClusterHeartBeat(HeartBeatMessage),
-    GetRole(tokio::sync::oneshot::Sender<String>),
+    GetRole(tokio::sync::oneshot::Sender<Role>),
     SubscribeToTopologyChange(
         tokio::sync::oneshot::Sender<tokio::sync::broadcast::Receiver<Vec<PeerIdentifier>>>,
     ),

--- a/duva/src/domains/cluster_actors/consensus/election.rs
+++ b/duva/src/domains/cluster_actors/consensus/election.rs
@@ -1,4 +1,4 @@
-use crate::domains::peers::identifier::PeerIdentifier;
+use crate::domains::{cluster_actors::replication::Role, peers::identifier::PeerIdentifier};
 
 #[derive(Debug, Clone)]
 pub(crate) enum ElectionState {
@@ -8,10 +8,10 @@ pub(crate) enum ElectionState {
 }
 
 impl ElectionState {
-    pub(crate) fn new(role: &str) -> Self {
+    pub(crate) fn new(role: &Role) -> Self {
         match role {
-            "leader" => ElectionState::Leader,
-            _ => ElectionState::Follower { voted_for: None },
+            Role::Leader => ElectionState::Leader,
+            Role::Follower => ElectionState::Follower { voted_for: None },
         }
     }
     pub(crate) fn become_leader(&mut self) {

--- a/duva/src/domains/cluster_actors/replication.rs
+++ b/duva/src/domains/cluster_actors/replication.rs
@@ -7,11 +7,26 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Role {
+    Leader,
+    Follower,
+}
+
+impl Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::Leader => write!(f, "leader"),
+            Role::Follower => write!(f, "follower"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicationState {
     pub(crate) replid: ReplicationId, // The replication ID of the master example: 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb
     pub(crate) hwm: Arc<AtomicU64>,   // high water mark (commit idx)
-    pub(crate) role: String,
+    pub(crate) role: Role,
 
     pub(crate) self_host: String,
     pub(crate) self_port: u16,
@@ -32,7 +47,7 @@ impl ReplicationState {
             ReplicationId::Undecided
         };
 
-        let role = if replicaof.is_some() { "follower".to_string() } else { "leader".to_string() };
+        let role = if replicaof.is_some() { Role::Follower } else { Role::Leader };
         let replication = ReplicationState {
             is_leader_mode: replicaof.is_none(),
             election_state: ElectionState::new(&role),
@@ -129,10 +144,10 @@ impl ReplicationState {
     pub(super) fn become_follower(&mut self, leader_id: Option<PeerIdentifier>) {
         self.election_state = ElectionState::Follower { voted_for: leader_id };
         self.is_leader_mode = false;
-        self.role = "follower".to_string();
+        self.role = Role::Follower;
     }
     pub(super) fn become_leader(&mut self) {
-        self.role = "leader".to_string();
+        self.role = Role::Leader;
         self.is_leader_mode = true;
         self.election_state.become_leader();
     }

--- a/duva/src/domains/peers/peer.rs
+++ b/duva/src/domains/peers/peer.rs
@@ -51,13 +51,27 @@ pub enum PeerState {
 
 impl PeerState {
     pub fn decide_peer_kind(my_repl_id: &ReplicationId, peer_info: &ConnectedPeerInfo) -> Self {
-        if peer_info.replid == ReplicationId::Undecided {
+        println!(
+            "[DEBUG] decide_peer_kind called for peer {:?}. My ReplId: {:?}, Peer ReplId: {:?}",
+            peer_info.id, my_repl_id, peer_info.replid
+        );
+
+        let decided_state = if peer_info.replid == ReplicationId::Undecided {
+            println!("[DEBUG] Peer ReplId is Undecided. Classifying as Replica.");
             PeerState::Replica { match_index: peer_info.hwm, replid: my_repl_id.clone() }
+        } else if my_repl_id == &ReplicationId::Undecided {
+            println!("[DEBUG] My ReplId is Undecided. Classifying as Replica.");
+            PeerState::Replica { match_index: peer_info.hwm, replid: peer_info.replid.clone() }
         } else if my_repl_id == &peer_info.replid {
+            println!("[DEBUG] ReplIds match. Classifying as Replica.");
             PeerState::Replica { match_index: peer_info.hwm, replid: peer_info.replid.clone() }
         } else {
+            println!("[DEBUG] ReplIds do NOT match. Classifying as NonDataPeer.");
             PeerState::NonDataPeer { match_index: peer_info.hwm, replid: peer_info.replid.clone() }
-        }
+        };
+
+        println!("[DEBUG] Decided PeerState for {:?}: {:?}", peer_info.id, decided_state);
+        decided_state
     }
 
     pub fn decrease_match_index(&mut self) {

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -13,6 +13,7 @@ use domains::caches::cache_manager::CacheManager;
 use domains::cluster_actors::ClusterActor;
 use domains::cluster_actors::commands::ClusterCommand;
 use domains::cluster_actors::replication::ReplicationState;
+use domains::cluster_actors::replication::Role;
 use domains::config_actors::config_manager::ConfigManager;
 use domains::saves::snapshot::snapshot_loader::SnapshotLoader;
 pub use init::Environment;
@@ -127,7 +128,8 @@ impl StartUpFacade {
             let mut peers = self.registry.cluster_communication_manager().get_peers().await?;
             peers.push(PeerIdentifier(self.registry.config_manager.bind_addr()));
 
-            let is_leader = self.registry.cluster_communication_manager().role().await? == "leader";
+            let is_leader =
+                self.registry.cluster_communication_manager().role().await? == Role::Leader;
             let Ok((reader, writer)) = authenticate(stream, peers, is_leader).await else {
                 eprintln!("[ERROR] Failed to authenticate client stream");
                 continue;

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -120,7 +120,7 @@ impl ClientController {
             },
             ClientAction::Role => {
                 let role = self.cluster_communication_manager.role();
-                QueryIO::SimpleString(role.await?)
+                QueryIO::SimpleString(role.await?.to_string())
             },
         };
         Ok(response)

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -2,7 +2,7 @@ use crate::{
     domains::{
         cluster_actors::{
             commands::{ClusterCommand, SyncLogs},
-            replication::ReplicationState,
+            replication::{ReplicationState, Role},
         },
         peers::identifier::PeerIdentifier,
         query_parsers::QueryIO,
@@ -76,7 +76,7 @@ impl ClusterCommunicationManager {
         Ok(rx.await?)
     }
 
-    pub(crate) async fn role(&self) -> anyhow::Result<String> {
+    pub(crate) async fn role(&self) -> anyhow::Result<Role> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.send(ClusterCommand::GetRole(tx)).await?;
         Ok(rx.await?)


### PR DESCRIPTION
Previously, new nodes attempting to join the cluster might have encountered issues if they connected directly to a follower node instead of the current leader. The connection and peer classification logic sometimes assumed the initial contact point would always be the leader.

This change enhances the peer discovery and handshake process to ensure that a new node can successfully join the cluster regardless of whether it initially connects to a leader or a follower.

Modifications include:
- Refining the `decide_peer_kind` logic to handle connections initiated towards followers more gracefully.
- Ensuring that follower nodes can correctly relay necessary cluster information (like the leader's identity and current ReplId) to the joining node.

This improvement increases the robustness and flexibility of the cluster joining mechanism, simplifying the process for adding new nodes, especially in dynamic environments or during leader transitions.

This resolves #455 
