### PR TITLE
fix: flaky test

### DIFF
--- a/duva/src/domains/caches/command.rs
+++ b/duva/src/domains/caches/command.rs
@@ -1,8 +1,6 @@
-use tokio::sync::{mpsc, oneshot};
-
-use crate::domains::{query_parsers::QueryIO, saves::command::SaveCommand};
-
 use super::cache_objects::{CacheEntry, CacheValue};
+use crate::domains::{query_parsers::QueryIO, saves::command::SaveCommand};
+use tokio::sync::{mpsc, oneshot};
 
 pub(crate) enum CacheCommand {
     Set { cache_entry: CacheEntry },


### PR DESCRIPTION
unique combination of

- multi-threaded test
- timing assumptions
- eventual consistency 

makes the test flaky. This PR is aimed at achieving determinism on the test 