### PR TITLE
Increase spawn_server_process timeout

### DIFF
--- a/duva/tests/common.rs
+++ b/duva/tests/common.rs
@@ -104,7 +104,7 @@ pub fn spawn_server_process(env: &ServerEnv) -> TestProcessChild {
         process.process.stdout.as_mut().unwrap(),
         vec![format!("listening peer connection on 127.0.0.1:{}...", env.port + 10000).as_str()],
         1,
-        Some(100000),
+        Some(20000),
     )
     .unwrap();
 

--- a/duva/tests/common.rs
+++ b/duva/tests/common.rs
@@ -104,7 +104,7 @@ pub fn spawn_server_process(env: &ServerEnv) -> TestProcessChild {
         process.process.stdout.as_mut().unwrap(),
         vec![format!("listening peer connection on 127.0.0.1:{}...", env.port + 10000).as_str()],
         1,
-        Some(10000),
+        Some(100000),
     )
     .unwrap();
 


### PR DESCRIPTION
# Explanation

Prevent timeout on spawn_server_process by increasing it, due to slow github action hosted CI environments.