### PR TITLE
run integrated tests with and without disk-based append only files

### DIFF
--- a/duva/src/adapters/op_logs/memory_based.rs
+++ b/duva/src/adapters/op_logs/memory_based.rs
@@ -13,6 +13,7 @@ impl TWriteAheadLog for MemoryOpLogs {
         self.writer.push(op);
         Ok(())
     }
+
     async fn append_many(&mut self, ops: Vec<WriteOperation>) -> Result<()> {
         self.writer.extend(ops);
         Ok(())

--- a/duva/src/domains/operation_logs/interfaces.rs
+++ b/duva/src/domains/operation_logs/interfaces.rs
@@ -1,15 +1,16 @@
 use super::WriteOperation;
 use anyhow::Result;
 
-/// Trait for an Append-Only File (WAL) abstraction.
+/// Trait for a write-ahead log (WAL) abstraction.
 pub trait TWriteAheadLog: Send + Sync + 'static {
     /// Appends a single `WriteOperation` to the log.
     fn append(&mut self, op: WriteOperation) -> impl Future<Output = Result<()>> + Send;
 
+    /// Append one or more `WriteOperation`s to the log.
     fn append_many(&mut self, ops: Vec<WriteOperation>) -> impl Future<Output = Result<()>> + Send;
 
-    // Retrieve logs that fall between the current 'commit' index and target 'log' index
-    // NOT async as it is expected to be infallible and memory operation.
+    /// Retrieve logs that fall between the current 'commit' index and target 'log' index.
+    /// This is NOT async as it is expected to be infallible and an in-memory operation.
     fn range(
         &self,
         start_exclusive: u64,
@@ -25,17 +26,21 @@ pub trait TWriteAheadLog: Send + Sync + 'static {
     /// Forces pending writes to be physically recorded on disk.
     fn fsync(&mut self) -> impl Future<Output = Result<()>> + Send;
 
-    // follower operation when replicating all the logs from leader
+    /// Replicate all logs from the leader. This is intended to only be called from a follower.
     fn follower_full_sync(
         &mut self,
         ops: Vec<WriteOperation>,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    /// Retrieves the log at a given index.
     fn read_at(&self, prev_log_index: u64) -> impl Future<Output = Option<WriteOperation>> + Send;
 
-    // If the log has been compacted (e.g., via snapshots), log_start_index will be greater than 1, meaning earlier entries have been processed.
+    /// If the log has been compacted (e.g., via snapshots), `log_start_index` will be greater than 1, meaning earlier entries have been processed.
     fn log_start_index(&self) -> u64;
 
+    /// Returns true if there are no logs. Otherwise, returns false.
     fn is_empty(&self) -> bool;
+
+    /// Truncate logs that are positioned after `log_index`.
     fn truncate_after(&mut self, log_index: u64) -> impl Future<Output = ()> + Send;
 }

--- a/duva/tests/client_ops/test_config_get_dir.rs
+++ b/duva/tests/client_ops/test_config_get_dir.rs
@@ -6,10 +6,8 @@ use tokio::time::sleep;
 
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_config_get_dir() -> anyhow::Result<()> {
+async fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     sleep(Duration::from_millis(500)).await;
@@ -19,7 +17,16 @@ async fn test_config_get_dir() -> anyhow::Result<()> {
     let res = h.send_and_get("CONFIG get dir", 1).await;
 
     // THEN
-    assert_eq!(res.first().unwrap(), "dir .");
+    assert_eq!(res.first().unwrap(), &format!("dir {}", env.dir.path().display()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_config_get_dir() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_config_get_dir(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_decr.rs
+++ b/duva/tests/client_ops/test_decr.rs
@@ -1,9 +1,7 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_decr() -> anyhow::Result<()> {
+async fn run_decr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -34,6 +32,15 @@ async fn test_decr() -> anyhow::Result<()> {
         h.send_and_get("DECR d", 1).await,
         vec!["(error) ERR value is not an integer or out of range"]
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_decr() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_decr(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_del.rs
+++ b/duva/tests/client_ops/test_del.rs
@@ -4,10 +4,8 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_del() -> anyhow::Result<()> {
+async fn run_del(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -22,6 +20,15 @@ async fn test_del() -> anyhow::Result<()> {
     // THEN
     let res = h.send_and_get("GET somanyrand", 1).await;
     assert_eq!(res, vec!["(nil)"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_del() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_del(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_exists.rs
+++ b/duva/tests/client_ops/test_exists.rs
@@ -4,10 +4,8 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_exists() -> anyhow::Result<()> {
+async fn run_exists(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -19,6 +17,15 @@ async fn test_exists() -> anyhow::Result<()> {
     assert_eq!(h.send_and_get("exists a c d", 1).await, vec!["(integer) 2"]);
 
     assert_eq!(h.send_and_get("exists x", 1).await, vec!["(integer) 0"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exists() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_exists(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_incr.rs
+++ b/duva/tests/client_ops/test_incr.rs
@@ -1,9 +1,7 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_incr() -> anyhow::Result<()> {
+async fn run_incr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -34,6 +32,15 @@ async fn test_incr() -> anyhow::Result<()> {
         h.send_and_get("INCR d", 1).await,
         vec!["(error) ERR value is not an integer or out of range"]
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_incr() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_incr(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_keys.rs
+++ b/duva/tests/client_ops/test_keys.rs
@@ -1,9 +1,7 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_keys() -> anyhow::Result<()> {
+async fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -19,6 +17,15 @@ async fn test_keys() -> anyhow::Result<()> {
     let res = h.send_and_get("KEYS *", 500).await;
 
     assert!(res.len() >= num_keys_to_store as usize);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_keys() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_keys(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_replication_info.rs
+++ b/duva/tests/client_ops/test_replication_info.rs
@@ -1,14 +1,11 @@
 /// Cache config should be injected to the handler!
 /// This is to enable client to configure things dynamically.
-
 /// if the value of dir is /tmp, then the expected response to CONFIG GET dir is:
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_replication_info() -> anyhow::Result<()> {
+async fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
     let mut h = Client::new(process.port);
 
@@ -20,6 +17,15 @@ async fn test_replication_info() -> anyhow::Result<()> {
     assert!(res[1].starts_with("leader_repl_id:"));
     assert_eq!(res[2], "high_watermark:0");
     assert_eq!(res[3], format!("self_identifier:127.0.0.1:{}", env.port));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_replication_info() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_replication_info(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_set_get.rs
+++ b/duva/tests/client_ops/test_set_get.rs
@@ -4,10 +4,8 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_set_get() -> anyhow::Result<()> {
+async fn run_set_get(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -22,6 +20,15 @@ async fn test_set_get() -> anyhow::Result<()> {
 
     let res = h.send_and_get("GET somanyrand", 1).await;
     assert_eq!(res, vec!["(nil)"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_set_get() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_set_get(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_ttl.rs
+++ b/duva/tests/client_ops/test_ttl.rs
@@ -1,9 +1,7 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_ttl() -> anyhow::Result<()> {
+async fn run_ttl(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
     let process = spawn_server_process(&env).await?;
 
     let mut h = Client::new(process.port);
@@ -16,6 +14,15 @@ async fn test_ttl() -> anyhow::Result<()> {
     // THEN
     assert_eq!(res, vec!["(integer) 4"]);
     assert_eq!(h.send_and_get("TTL non_existing_key", 1).await, vec!["(integer) -1"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ttl() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_ttl(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
@@ -2,11 +2,11 @@
 /// In other words the specified node is removed from the nodes table of the node receiving the command.
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_cluster_forget_node_return_error_when_wrong_id_given() -> anyhow::Result<()> {
+async fn run_cluster_forget_node_return_error_when_wrong_id_given(
+    env: ServerEnv,
+) -> anyhow::Result<()> {
     // GIVEN
 
-    let env = ServerEnv::default();
     let leader_p = spawn_server_process(&env).await?;
 
     // WHEN
@@ -23,6 +23,15 @@ async fn test_cluster_forget_node_return_error_when_wrong_id_given() -> anyhow::
 
     // THEN
     assert_eq!(cluster_info.first().unwrap(), "cluster_known_nodes:0");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cluster_forget_node_return_error_when_wrong_id_given() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_cluster_forget_node_return_error_when_wrong_id_given(env).await?;
+    }
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_heartbeat.rs
+++ b/duva/tests/cluster_ops/test_heartbeat.rs
@@ -3,19 +3,22 @@
 //! In this case, the server will send PING message to the follower and the follower will respond with PONG message
 use crate::common::{ServerEnv, check_internodes_communication, spawn_server_process};
 
-#[tokio::test]
-async fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
+async fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow::Result<()> {
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     // GIVEN
 
-    let env = ServerEnv::default();
+    let env = ServerEnv::default().with_append_only(with_append_only);
     let mut leader_p = spawn_server_process(&env).await?;
     let leader_bind_addr = leader_p.bind_addr().clone();
-    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_bind_addr.clone().into());
+    let repl_env = ServerEnv::default()
+        .with_leader_bind_addr(leader_bind_addr.clone())
+        .with_append_only(with_append_only);
     let mut follower_p1 = spawn_server_process(&repl_env).await?;
 
-    let repl_env2 = ServerEnv::default().with_leader_bind_addr(leader_bind_addr.clone().into());
+    let repl_env2 = ServerEnv::default()
+        .with_leader_bind_addr(leader_bind_addr.clone())
+        .with_append_only(with_append_only);
     let mut follower_p2 = spawn_server_process(&repl_env2).await?;
     let mut processes = vec![&mut leader_p, &mut follower_p1, &mut follower_p2];
 
@@ -24,7 +27,9 @@ async fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
         .unwrap();
 
     // WHEN run Third follower
-    let repl_env3 = ServerEnv::default().with_leader_bind_addr(leader_bind_addr.clone().into());
+    let repl_env3 = ServerEnv::default()
+        .with_leader_bind_addr(leader_bind_addr.clone())
+        .with_append_only(with_append_only);
     let mut follower_p3 = spawn_server_process(&repl_env3).await?;
     processes.push(&mut follower_p3);
 
@@ -37,19 +42,22 @@ async fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
+async fn run_heartbeat_hop_count_starts_with_0(with_append_only: bool) -> anyhow::Result<()> {
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
 
     // GIVEN
-    let env = ServerEnv::default();
+    let env = ServerEnv::default().with_append_only(with_append_only);
     let mut leader_p = spawn_server_process(&env).await?;
 
     // WHEN
-    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into());
+    let repl_env = ServerEnv::default()
+        .with_leader_bind_addr(leader_p.bind_addr())
+        .with_append_only(with_append_only);
     let mut follower_p1 = spawn_server_process(&repl_env).await?;
-    let repl_env2 = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into());
+    let repl_env2 = ServerEnv::default()
+        .with_leader_bind_addr(leader_p.bind_addr())
+        .with_append_only(with_append_only);
     let mut follower_p2 = spawn_server_process(&repl_env2).await?;
 
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
@@ -61,6 +69,22 @@ async fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
     let res =
         check_internodes_communication(processes, DEFAULT_HOP_COUNT + 1, TIMEOUT_IN_MILLIS).await;
     assert!(res.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
+    run_heartbeat_hop_count_decreases_over_time(false).await?;
+    run_heartbeat_hop_count_decreases_over_time(true).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
+    run_heartbeat_hop_count_starts_with_0(false).await?;
+    run_heartbeat_hop_count_starts_with_0(true).await?;
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_sync.rs
+++ b/duva/tests/replication_ops/test_sync.rs
@@ -1,9 +1,9 @@
 use crate::common::{Client, ServerEnv, check_internodes_communication, spawn_server_process};
 
-#[tokio::test]
-async fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
+async fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
-    let env = ServerEnv::default();
+    let env = ServerEnv::default().with_append_only(with_append_only);
+
     // Start the leader server as a child process
     let mut leader_p = spawn_server_process(&env).await?;
     let mut h = Client::new(leader_p.port);
@@ -11,7 +11,9 @@ async fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
     h.send_and_get("SET foo bar", 1).await;
 
     // WHEN run replica
-    let repl_env = ServerEnv::default().with_leader_bind_addr(leader_p.bind_addr().into());
+    let repl_env = ServerEnv::default()
+        .with_leader_bind_addr(leader_p.bind_addr())
+        .with_append_only(with_append_only);
 
     let mut replica_process = spawn_server_process(&repl_env).await?;
     check_internodes_communication(&mut [&mut leader_p, &mut replica_process], 0, 1000).await?;
@@ -19,6 +21,14 @@ async fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
     // THEN
     let mut client_to_repl = Client::new(replica_process.port);
     assert_eq!(client_to_repl.send_and_get("KEYS *", 1).await, vec!["0) \"foo\""]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
+    run_full_sync_on_newly_added_replica(false).await?;
+    run_full_sync_on_newly_added_replica(true).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Updated out integrated tests to run with and without append only files. 

As a drive-by change, created a temporary directory for each ServerEnv, and passed that as the base dir to the application (topology file path is defined in this temporary directory with a random file name).

Resolved #511 