### PR TITLE
fix: vscode debugging settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,150 +7,18 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'duva'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--lib",
-                    "--package=duva"
-                ],
-                "filter": {
-                    "name": "duva",
-                    "kind": "lib"
-                }
-            },
+            "preLaunchTask": "Cargo debug build",
+            "name": "Debug duva",
+            "program": "${workspaceFolder}/target/debug/duva",
             "args": [],
             "cwd": "${workspaceFolder}"
         },
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'duva'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=duva",
-                    "--package=duva"
-                ],
-                "filter": {
-                    "name": "duva",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in executable 'duva'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=duva",
-                    "--package=duva"
-                ],
-                "filter": {
-                    "name": "duva",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug integration test 'common'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--test=common",
-                    "--package=duva"
-                ],
-                "filter": {
-                    "name": "common",
-                    "kind": "test"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug integration test 'test_mods'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--test=test_mods",
-                    "--package=duva"
-                ],
-                "filter": {
-                    "name": "test_mods",
-                    "kind": "test"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in library 'duva_client'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--lib",
-                    "--package=duva-client"
-                ],
-                "filter": {
-                    "name": "duva_client",
-                    "kind": "lib"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug executable 'cli'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=cli",
-                    "--package=duva-client"
-                ],
-                "filter": {
-                    "name": "cli",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in executable 'cli'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=cli",
-                    "--package=duva-client"
-                ],
-                "filter": {
-                    "name": "cli",
-                    "kind": "bin"
-                }
-            },
+            "preLaunchTask": "Cargo debug build",
+            "name": "Debug duva-cli",
+            "program": "${workspaceFolder}/target/debug/cli",
             "args": [],
             "cwd": "${workspaceFolder}"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Cargo debug build",
+            "command": "cargo",
+            "args": ["build"],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
rust debugging fails when some print comes out

that's bug of lldb extension that reading inputs as json for resolving some artifacts information.

I changed it to separate building and launching process