### PR TITLE
bug: zombie process due to async-based test 

### DIFF
--- a/duva-client/src/broker/mod.rs
+++ b/duva-client/src/broker/mod.rs
@@ -111,7 +111,8 @@ impl Broker {
         server_addr: &str,
         auth_request: Option<AuthRequest>,
     ) -> Result<(ServerStreamReader, ServerStreamWriter, AuthResponse), IoError> {
-        let mut stream = TcpStream::connect(server_addr).await.unwrap();
+        let mut stream =
+            TcpStream::connect(server_addr).await.map_err(|_| IoError::NotConnected)?;
 
         stream.serialized_write(auth_request.unwrap_or_default()).await.unwrap(); // client_id not exist
         let auth_response: AuthResponse = stream.deserialized_read().await?;

--- a/duva-client/src/cli/main.rs
+++ b/duva-client/src/cli/main.rs
@@ -2,7 +2,10 @@ mod cli;
 mod editor;
 use clap::Parser;
 use duva::{
-    prelude::tokio::{self, sync::oneshot},
+    prelude::{
+        anyhow,
+        tokio::{self, sync::oneshot},
+    },
     presentation::clients::request::extract_action,
 };
 use duva_client::{
@@ -14,11 +17,11 @@ use duva_client::{
 const PROMPT: &str = "duva-cli> ";
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     clear_and_make_ascii_art();
 
     let cli = cli::Cli::parse();
-    let mut controller = ClientController::new(editor::create(), &cli.address()).await;
+    let mut controller = ClientController::new(editor::create(), &cli.address()).await?;
 
     loop {
         let readline = controller.target.readline(PROMPT).unwrap_or_else(|_| std::process::exit(0));
@@ -51,6 +54,7 @@ async fn main() {
             },
         }
     }
+    Ok(())
 }
 
 fn clear_and_make_ascii_art() {

--- a/duva/src/domains/cluster_actors/hash_ring.rs
+++ b/duva/src/domains/cluster_actors/hash_ring.rs
@@ -524,7 +524,7 @@ mod tests {
 
         // Handle normal ranges
         if start1 < end1 && start2 < end2 {
-            return (start1 < end2 && end1 > start2);
+            return start1 < end2 && end1 > start2;
         }
 
         // Handle wrap-around ranges

--- a/duva/tests/client_ops/test_append.rs
+++ b/duva/tests/client_ops/test_append.rs
@@ -8,7 +8,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 async fn test_append() -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default();
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 

--- a/duva/tests/client_ops/test_append.rs
+++ b/duva/tests/client_ops/test_append.rs
@@ -4,11 +4,11 @@
 /// After immediately, we append latter string with used key before and check if it's result same as concatted one
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-#[tokio::test]
-async fn test_append() -> anyhow::Result<()> {
+#[test]
+fn test_append() -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default();
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
@@ -17,20 +17,20 @@ async fn test_append() -> anyhow::Result<()> {
 
     // WHEN - append first value
     assert_eq!(
-        h.send_and_get(format!("APPEND appended_one {first}"), 1).await,
+        h.send_and_get(format!("APPEND appended_one {first}"), 1),
         vec![first.len().to_string()]
     );
     // THEN
-    let res = h.send_and_get("GET appended_one", 1).await;
+    let res = h.send_and_get("GET appended_one", 1);
     assert_eq!(res, vec!["Hello"]);
 
     // WHEN - append second value
     assert_eq!(
-        h.send_and_get(format!("APPEND appended_one {second}"), 1).await,
+        h.send_and_get(format!("APPEND appended_one {second}"), 1),
         vec![(first.len() + second.len()).to_string()]
     );
     // THEN
-    let res = h.send_and_get("GET appended_one", 1).await;
+    let res = h.send_and_get("GET appended_one", 1);
     assert_eq!(res, vec!["HelloWorld!"]);
 
     Ok(())

--- a/duva/tests/client_ops/test_config_get_dir.rs
+++ b/duva/tests/client_ops/test_config_get_dir.rs
@@ -1,20 +1,18 @@
 /// if the value of dir is /tmp, then the expected response to CONFIG GET dir is:
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
-use std::time::Duration;
-
-use tokio::time::sleep;
+use std::{thread::sleep, time::Duration};
 
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
+fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
-    sleep(Duration::from_millis(500)).await;
+    sleep(Duration::from_millis(500));
     let mut h = Client::new(process.port);
 
     // WHEN
-    let res = h.send_and_get("CONFIG get dir", 1).await;
+    let res = h.send_and_get("CONFIG get dir", 1);
 
     // THEN
     assert_eq!(res.first().unwrap(), &format!("dir {}", env.dir.path().display()));
@@ -22,10 +20,10 @@ async fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_config_get_dir() -> anyhow::Result<()> {
+#[test]
+fn test_config_get_dir() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_config_get_dir(env).await?;
+        run_config_get_dir(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_config_get_dir.rs
+++ b/duva/tests/client_ops/test_config_get_dir.rs
@@ -8,7 +8,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     sleep(Duration::from_millis(500)).await;
     let mut h = Client::new(process.port);

--- a/duva/tests/client_ops/test_decr.rs
+++ b/duva/tests/client_ops/test_decr.rs
@@ -1,45 +1,45 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_decr(env: ServerEnv) -> anyhow::Result<()> {
+fn run_decr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
     // WHEN
-    assert_eq!(h.send_and_get("DECR a", 1).await, vec!["(integer) -1"]);
-    assert_eq!(h.send_and_get("DECR a", 1).await, vec!["(integer) -2"]);
-    assert_eq!(h.send_and_get("DECR a", 1).await, vec!["(integer) -3"]);
+    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -1"]);
+    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -2"]);
+    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -3"]);
 
     // THEN
-    assert_eq!(h.send_and_get("GET a", 1).await, vec!["-3"]);
-    assert_eq!(h.send_and_get("INCR b", 1).await, vec!["(integer) 1"]);
-    assert_eq!(h.send_and_get("DECR b", 1).await, vec!["(integer) 0"]);
+    assert_eq!(h.send_and_get("GET a", 1), vec!["-3"]);
+    assert_eq!(h.send_and_get("INCR b", 1), vec!["(integer) 1"]);
+    assert_eq!(h.send_and_get("DECR b", 1), vec!["(integer) 0"]);
 
     // WHEN
-    assert_eq!(h.send_and_get("SET c adsds", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c adsds", 1), vec!["OK"]);
 
     // THEN
     assert_eq!(
-        h.send_and_get("DECR c", 1).await,
+        h.send_and_get("DECR c", 1),
         vec!["(error) ERR value is not an integer or out of range"]
     );
 
     // WHEN - out of range
-    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1), vec!["OK"]);
     // THEN
     assert_eq!(
-        h.send_and_get("DECR d", 1).await,
+        h.send_and_get("DECR d", 1),
         vec!["(error) ERR value is not an integer or out of range"]
     );
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_decr() -> anyhow::Result<()> {
+#[test]
+fn test_decr() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_decr(env).await?;
+        run_decr(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_decr.rs
+++ b/duva/tests/client_ops/test_decr.rs
@@ -2,7 +2,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_decr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 

--- a/duva/tests/client_ops/test_del.rs
+++ b/duva/tests/client_ops/test_del.rs
@@ -6,7 +6,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_del(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
     assert_eq!(h.send_and_get("SET a b", 1).await, vec!["OK"]);

--- a/duva/tests/client_ops/test_del.rs
+++ b/duva/tests/client_ops/test_del.rs
@@ -4,30 +4,30 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_del(env: ServerEnv) -> anyhow::Result<()> {
+fn run_del(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
-    assert_eq!(h.send_and_get("SET a b", 1).await, vec!["OK"]);
-    assert_eq!(h.send_and_get("SET c d", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET a b", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c d", 1), vec!["OK"]);
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("del a c d", 1).await, vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("del a c d", 1), vec!["(integer) 2"]);
 
-    assert_eq!(h.send_and_get("get a", 1).await, vec!["(nil)"]);
+    assert_eq!(h.send_and_get("get a", 1), vec!["(nil)"]);
 
     // THEN
-    let res = h.send_and_get("GET somanyrand", 1).await;
+    let res = h.send_and_get("GET somanyrand", 1);
     assert_eq!(res, vec!["(nil)"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_del() -> anyhow::Result<()> {
+#[test]
+fn test_del() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_del(env).await?;
+        run_del(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_exists.rs
+++ b/duva/tests/client_ops/test_exists.rs
@@ -6,7 +6,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_exists(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
     assert_eq!(h.send_and_get("SET a b", 1).await, vec!["OK"]);

--- a/duva/tests/client_ops/test_exists.rs
+++ b/duva/tests/client_ops/test_exists.rs
@@ -4,27 +4,27 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_exists(env: ServerEnv) -> anyhow::Result<()> {
+fn run_exists(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
-    assert_eq!(h.send_and_get("SET a b", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET a b", 1), vec!["OK"]);
 
-    assert_eq!(h.send_and_get("SET c d", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c d", 1), vec!["OK"]);
 
     // WHEN & THEN
-    assert_eq!(h.send_and_get("exists a c d", 1).await, vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("exists a c d", 1), vec!["(integer) 2"]);
 
-    assert_eq!(h.send_and_get("exists x", 1).await, vec!["(integer) 0"]);
+    assert_eq!(h.send_and_get("exists x", 1), vec!["(integer) 0"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_exists() -> anyhow::Result<()> {
+#[test]
+fn test_exists() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_exists(env).await?;
+        run_exists(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_incr.rs
+++ b/duva/tests/client_ops/test_incr.rs
@@ -2,7 +2,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_incr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 

--- a/duva/tests/client_ops/test_incr.rs
+++ b/duva/tests/client_ops/test_incr.rs
@@ -1,45 +1,45 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_incr(env: ServerEnv) -> anyhow::Result<()> {
+fn run_incr(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
     // WHEN
-    assert_eq!(h.send_and_get("INCR a", 1).await, vec!["(integer) 1"]);
-    assert_eq!(h.send_and_get("INCR a", 1).await, vec!["(integer) 2"]);
-    assert_eq!(h.send_and_get("INCR a", 1).await, vec!["(integer) 3"]);
+    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 1"]);
+    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 3"]);
 
     // THEN
-    assert_eq!(h.send_and_get("GET a", 1).await, vec!["3"]);
-    assert_eq!(h.send_and_get("INCR b", 1).await, vec!["(integer) 1"]);
-    assert_eq!(h.send_and_get("INCR b", 1).await, vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("GET a", 1), vec!["3"]);
+    assert_eq!(h.send_and_get("INCR b", 1), vec!["(integer) 1"]);
+    assert_eq!(h.send_and_get("INCR b", 1), vec!["(integer) 2"]);
 
     // WHEN
-    assert_eq!(h.send_and_get("SET c adsds", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c adsds", 1), vec!["OK"]);
 
     // THEN
     assert_eq!(
-        h.send_and_get("INCR c", 1).await,
+        h.send_and_get("INCR c", 1),
         vec!["(error) ERR value is not an integer or out of range"]
     );
 
     // WHEN - out of range
-    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1), vec!["OK"]);
     // THEN
     assert_eq!(
-        h.send_and_get("INCR d", 1).await,
+        h.send_and_get("INCR d", 1),
         vec!["(error) ERR value is not an integer or out of range"]
     );
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_incr() -> anyhow::Result<()> {
+#[test]
+fn test_incr() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_incr(env).await?;
+        run_incr(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_keys.rs
+++ b/duva/tests/client_ops/test_keys.rs
@@ -2,11 +2,11 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 
-    let num_keys_to_store = 124;
+    let num_keys_to_store = 2000;
 
     // WHEN set 500 keys with the value `bar`.
     for key in 0..num_keys_to_store {

--- a/duva/tests/client_ops/test_keys.rs
+++ b/duva/tests/client_ops/test_keys.rs
@@ -1,8 +1,8 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
+fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
@@ -10,21 +10,21 @@ async fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
 
     // WHEN set 500 keys with the value `bar`.
     for key in 0..num_keys_to_store {
-        h.send_and_get(format!("SET {} bar", key), 1).await;
+        h.send_and_get(format!("SET {} bar", key), 1);
     }
 
     // Fire keys command
-    let res = h.send_and_get("KEYS *", num_keys_to_store).await;
+    let res = h.send_and_get("KEYS *", num_keys_to_store);
 
     assert!(res.len() >= num_keys_to_store as usize);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_keys() -> anyhow::Result<()> {
+#[test]
+fn test_keys() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_keys(env).await?;
+        run_keys(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_replication_info.rs
+++ b/duva/tests/client_ops/test_replication_info.rs
@@ -6,7 +6,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
     let mut h = Client::new(process.port);
 
     // WHEN

--- a/duva/tests/client_ops/test_replication_info.rs
+++ b/duva/tests/client_ops/test_replication_info.rs
@@ -4,13 +4,13 @@
 /// *2\r\n$3\r\ndir\r\n$4\r\n/tmp\r\n
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
+fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
     let mut h = Client::new(process.port);
 
     // WHEN
-    let res = h.send_and_get("INFO replication", 4).await;
+    let res = h.send_and_get("INFO replication", 4);
 
     // THEN
     assert_eq!(res[0], "role:leader");
@@ -21,10 +21,10 @@ async fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_replication_info() -> anyhow::Result<()> {
+#[test]
+fn test_replication_info() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_replication_info(env).await?;
+        run_replication_info(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_set_get.rs
+++ b/duva/tests/client_ops/test_set_get.rs
@@ -6,7 +6,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_set_get(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 

--- a/duva/tests/client_ops/test_set_get.rs
+++ b/duva/tests/client_ops/test_set_get.rs
@@ -4,30 +4,30 @@
 /// After 300ms, we get the key again and check if the value is not returned (-1)
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_set_get(env: ServerEnv) -> anyhow::Result<()> {
+fn run_set_get(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("SET somanyrand bar PX 300", 1).await, vec!["OK"]);
-    let res = h.send_and_get("GET somanyrand", 1).await;
+    assert_eq!(h.send_and_get("SET somanyrand bar PX 300", 1), vec!["OK"]);
+    let res = h.send_and_get("GET somanyrand", 1);
     assert_eq!(res, vec!["bar"]);
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    std::thread::sleep(std::time::Duration::from_millis(300));
     // THEN
 
-    let res = h.send_and_get("GET somanyrand", 1).await;
+    let res = h.send_and_get("GET somanyrand", 1);
     assert_eq!(res, vec!["(nil)"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_set_get() -> anyhow::Result<()> {
+#[test]
+fn test_set_get() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_set_get(env).await?;
+        run_set_get(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
+++ b/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
@@ -5,7 +5,7 @@ use std::time::UNIX_EPOCH;
 
 async fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let mut leader_process = spawn_server_process(&env).await?;
+    let mut leader_process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(leader_process.port);
 
@@ -30,7 +30,7 @@ async fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Res
     let _ = leader_process.terminate().await;
 
     // run server with the same file name
-    let new_process = spawn_server_process(&env).await?;
+    let new_process = spawn_server_process(&env, false).await?;
 
     let mut client = Client::new(new_process.port);
 

--- a/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
+++ b/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
@@ -3,41 +3,41 @@ use crate::common::{ServerEnv, spawn_server_process};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-async fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Result<()> {
+fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let mut leader_process = spawn_server_process(&env, false).await?;
+    let mut leader_process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(leader_process.port);
 
     // WHEN
     // set without expiry time
-    let res = h.send_and_get("SET foo bar", 1).await;
+    let res = h.send_and_get("SET foo bar", 1);
     assert_eq!(res, vec!["OK"]);
 
     // set with expiry time
-    assert_eq!(h.send_and_get("SET foo2 bar2 PX 9999999999", 1).await, vec!["OK"]);
+    assert_eq!(h.send_and_get("SET foo2 bar2 PX 9999999999", 1), vec!["OK"]);
 
     // check keys
-    assert_eq!(h.send_and_get("KEYS *", 2).await, vec!["0) \"foo2\"", "1) \"foo\""]);
+    assert_eq!(h.send_and_get("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
 
     // check replication info
-    let info = h.send_and_get("INFO replication", 4).await;
+    let info = h.send_and_get("INFO replication", 4);
 
     // WHEN
-    assert_eq!(h.send_and_get("SAVE", 1).await, vec!["(nil)"]);
+    assert_eq!(h.send_and_get("SAVE", 1), vec!["(nil)"]);
 
     // kill leader process
-    let _ = leader_process.terminate().await;
+    let _ = leader_process.terminate();
 
     // run server with the same file name
-    let new_process = spawn_server_process(&env, false).await?;
+    let new_process = spawn_server_process(&env, false)?;
 
     let mut client = Client::new(new_process.port);
 
-    assert_eq!(client.send_and_get("KEYS *", 2).await, vec!["0) \"foo2\"", "1) \"foo\""]);
+    assert_eq!(client.send_and_get("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
 
     // replication info
-    let info2 = client.send_and_get("INFO replication", 4).await;
+    let info2 = client.send_and_get("INFO replication", 4);
 
     // THEN
     assert_eq!(info, info2);
@@ -59,7 +59,7 @@ async fn test_snapshot_persists_and_recovers_state() -> anyhow::Result<()> {
             .with_file_name(create_unique_file_name("test_save_dump"))
             .with_append_only(true),
     ] {
-        run_snapshot_persists_and_recovers_state(env).await?;
+        run_snapshot_persists_and_recovers_state(env)?;
     }
 
     Ok(())

--- a/duva/tests/client_ops/test_ttl.rs
+++ b/duva/tests/client_ops/test_ttl.rs
@@ -2,7 +2,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_ttl(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env).await?;
+    let process = spawn_server_process(&env, false).await?;
 
     let mut h = Client::new(process.port);
 

--- a/duva/tests/client_ops/test_ttl.rs
+++ b/duva/tests/client_ops/test_ttl.rs
@@ -1,27 +1,27 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_ttl(env: ServerEnv) -> anyhow::Result<()> {
+fn run_ttl(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
-    let process = spawn_server_process(&env, false).await?;
+    let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("SET somanyrand bar PX 5000", 1).await, vec!["OK"]);
-    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await; // slight delay so seconds gets floored
-    let res = h.send_and_get("TTL somanyrand", 1).await;
+    assert_eq!(h.send_and_get("SET somanyrand bar PX 5000", 1), vec!["OK"]);
+    std::thread::sleep(tokio::time::Duration::from_millis(10)); // slight delay so seconds gets floored
+    let res = h.send_and_get("TTL somanyrand", 1);
 
     // THEN
     assert_eq!(res, vec!["(integer) 4"]);
-    assert_eq!(h.send_and_get("TTL non_existing_key", 1).await, vec!["(integer) -1"]);
+    assert_eq!(h.send_and_get("TTL non_existing_key", 1), vec!["(integer) -1"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_ttl() -> anyhow::Result<()> {
+#[test]
+fn test_ttl() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_ttl(env).await?;
+        run_ttl(env)?;
     }
 
     Ok(())

--- a/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
@@ -9,19 +9,19 @@ async fn run_cluster_forget_makes_all_nodes_forget_target_node(
     const HOP_COUNT: usize = 0;
 
     let env = ServerEnv::default().with_ttl(500).with_hf(2).with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr().clone())
         .with_hf(10)
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true).await?;
 
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr().clone())
         .with_hf(10)
         .with_append_only(with_append_only);
-    let mut repl_p2 = spawn_server_process(&repl_env2).await?;
+    let mut repl_p2 = spawn_server_process(&repl_env2, true).await?;
 
     check_internodes_communication(
         &mut [&mut leader_p, &mut repl_p, &mut repl_p2],

--- a/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
@@ -2,58 +2,57 @@ use duva::domains::cluster_actors::heartbeats::scheduler::LEADER_HEARTBEAT_INTER
 
 use crate::common::{Client, ServerEnv, check_internodes_communication, spawn_server_process};
 
-async fn run_cluster_forget_makes_all_nodes_forget_target_node(
+fn run_cluster_forget_makes_all_nodes_forget_target_node(
     with_append_only: bool,
 ) -> anyhow::Result<()> {
     // GIVEN
     const HOP_COUNT: usize = 0;
 
     let env = ServerEnv::default().with_ttl(500).with_hf(2).with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr().clone())
         .with_hf(10)
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env, true).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true)?;
 
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr().clone())
         .with_hf(10)
         .with_append_only(with_append_only);
-    let mut repl_p2 = spawn_server_process(&repl_env2, true).await?;
+    let mut repl_p2 = spawn_server_process(&repl_env2, true)?;
 
     check_internodes_communication(
         &mut [&mut leader_p, &mut repl_p, &mut repl_p2],
         HOP_COUNT,
         1000,
-    )
-    .await?;
+    )?;
 
     // WHEN
     let mut client_handler = Client::new(leader_p.port);
     let replica_id = repl_p.bind_addr();
-    let response1 = client_handler.send_and_get(format!("cluster forget {}", &replica_id), 1).await;
+    let response1 = client_handler.send_and_get(format!("cluster forget {}", &replica_id), 1);
     assert_eq!(response1, vec!["OK"]);
 
     // THEN
-    let response2 = client_handler.send_and_get("cluster info", 1).await;
+    let response2 = client_handler.send_and_get("cluster info", 1);
     assert_eq!(response2.first().unwrap(), "cluster_known_nodes:1");
 
     let mut repl_cli = Client::new(repl_p2.port);
 
-    tokio::time::sleep(std::time::Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX + 1)).await;
+    std::thread::sleep(std::time::Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX + 1));
 
-    let response2 = repl_cli.send_and_get("cluster info", 1).await;
+    let response2 = repl_cli.send_and_get("cluster info", 1);
     assert_eq!(response2.first().unwrap(), "cluster_known_nodes:1");
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_cluster_forget_makes_all_nodes_forget_target_node() -> anyhow::Result<()> {
-    run_cluster_forget_makes_all_nodes_forget_target_node(false).await?;
-    run_cluster_forget_makes_all_nodes_forget_target_node(true).await?;
+#[test]
+fn test_cluster_forget_makes_all_nodes_forget_target_node() -> anyhow::Result<()> {
+    run_cluster_forget_makes_all_nodes_forget_target_node(false)?;
+    run_cluster_forget_makes_all_nodes_forget_target_node(true)?;
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
@@ -2,24 +2,22 @@
 /// In other words the specified node is removed from the nodes table of the node receiving the command.
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_cluster_forget_node_return_error_when_wrong_id_given(
-    env: ServerEnv,
-) -> anyhow::Result<()> {
+fn run_cluster_forget_node_return_error_when_wrong_id_given(env: ServerEnv) -> anyhow::Result<()> {
     // GIVEN
 
-    let leader_p = spawn_server_process(&env, true).await?;
+    let leader_p = spawn_server_process(&env, true)?;
 
     // WHEN
     let mut client_handler = Client::new(leader_p.port);
     let replica_id = "localhost:19933";
     let cmd = format!("cluster forget {}", &replica_id);
-    let cluster_info = client_handler.send_and_get(&cmd, 1).await;
+    let cluster_info = client_handler.send_and_get(&cmd, 1);
 
     // THEN
     assert_eq!(cluster_info.first().unwrap(), "(error) No such peer");
 
     // WHEN
-    let cluster_info = client_handler.send_and_get("cluster info", 1).await;
+    let cluster_info = client_handler.send_and_get("cluster info", 1);
 
     // THEN
     assert_eq!(cluster_info.first().unwrap(), "cluster_known_nodes:0");
@@ -27,10 +25,10 @@ async fn run_cluster_forget_node_return_error_when_wrong_id_given(
     Ok(())
 }
 
-#[tokio::test]
-async fn test_cluster_forget_node_return_error_when_wrong_id_given() -> anyhow::Result<()> {
+#[test]
+fn test_cluster_forget_node_return_error_when_wrong_id_given() -> anyhow::Result<()> {
     for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
-        run_cluster_forget_node_return_error_when_wrong_id_given(env).await?;
+        run_cluster_forget_node_return_error_when_wrong_id_given(env)?;
     }
 
     Ok(())

--- a/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
@@ -7,7 +7,7 @@ async fn run_cluster_forget_node_return_error_when_wrong_id_given(
 ) -> anyhow::Result<()> {
     // GIVEN
 
-    let leader_p = spawn_server_process(&env).await?;
+    let leader_p = spawn_server_process(&env, true).await?;
 
     // WHEN
     let mut client_handler = Client::new(leader_p.port);

--- a/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
+++ b/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
@@ -1,42 +1,39 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_cluster_topology_change_when_new_node_added(
-    with_append_only: bool,
-) -> anyhow::Result<()> {
+fn run_cluster_topology_change_when_new_node_added(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
 
     let cmd = "cluster info";
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env, true).await?;
-    repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
-    leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true)?;
+    repl_p.wait_for_message(&leader_p.heartbeat_msg(0))?;
+    leader_p.wait_for_message(&repl_p.heartbeat_msg(0))?;
 
     let mut client_handler = Client::new(leader_p.port);
-    let cluster_info = client_handler.send_and_get(cmd.as_bytes(), 1).await;
+    let cluster_info = client_handler.send_and_get(cmd.as_bytes(), 1);
     assert_eq!(cluster_info, vec!["cluster_known_nodes:1".to_string()]);
 
     // WHEN -- new replica is added
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut new_repl_p = spawn_server_process(&repl_env2, true).await?;
-    new_repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
+    let mut new_repl_p = spawn_server_process(&repl_env2, true)?;
+    new_repl_p.wait_for_message(&leader_p.heartbeat_msg(0))?;
 
     //THEN
-    let cluster_info = client_handler.send_and_get(cmd.as_bytes(), 1).await;
+    let cluster_info = client_handler.send_and_get(cmd.as_bytes(), 1);
     assert_eq!(cluster_info, vec!["cluster_known_nodes:2".to_string()]);
 
-    let nodes = client_handler.send_and_get("cluster nodes".as_bytes(), 3).await;
+    let nodes = client_handler.send_and_get("cluster nodes".as_bytes(), 3);
     assert_eq!(nodes.len(), 3);
 
     let mut leader_nodes = Vec::new();
-    tokio::fs::read_to_string(&env.topology_path)
-        .await
+    std::fs::read_to_string(&env.topology_path)
         .unwrap()
         .lines()
         .for_each(|line| leader_nodes.push(line.to_string()));
@@ -48,10 +45,10 @@ async fn run_cluster_topology_change_when_new_node_added(
     Ok(())
 }
 
-#[tokio::test]
-async fn test_cluster_topology_change_when_new_node_added() -> anyhow::Result<()> {
-    run_cluster_topology_change_when_new_node_added(false).await?;
-    run_cluster_topology_change_when_new_node_added(true).await?;
+#[test]
+fn test_cluster_topology_change_when_new_node_added() -> anyhow::Result<()> {
+    run_cluster_topology_change_when_new_node_added(false)?;
+    run_cluster_topology_change_when_new_node_added(true)?;
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
+++ b/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
@@ -5,14 +5,14 @@ async fn run_cluster_topology_change_when_new_node_added(
 ) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
 
     let cmd = "cluster info";
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true).await?;
     repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
     leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;
 
@@ -24,7 +24,7 @@ async fn run_cluster_topology_change_when_new_node_added(
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut new_repl_p = spawn_server_process(&repl_env2).await?;
+    let mut new_repl_p = spawn_server_process(&repl_env2, true).await?;
     new_repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
 
     //THEN

--- a/duva/tests/cluster_ops/test_heartbeat.rs
+++ b/duva/tests/cluster_ops/test_heartbeat.rs
@@ -4,88 +4,84 @@
 
 use crate::common::{ServerEnv, check_internodes_communication, spawn_server_process};
 
-async fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow::Result<()> {
+fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow::Result<()> {
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     // GIVEN
 
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
     let leader_bind_addr = leader_p.bind_addr().clone();
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&repl_env, true).await?;
+    let mut follower_p1 = spawn_server_process(&repl_env, true)?;
 
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&repl_env2, true).await?;
+    let mut follower_p2 = spawn_server_process(&repl_env2, true)?;
     let mut processes = vec![&mut leader_p, &mut follower_p1, &mut follower_p2];
 
-    check_internodes_communication(&mut processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)
-        .await
-        .unwrap();
+    check_internodes_communication(&mut processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).unwrap();
 
     // WHEN run Third follower
     let repl_env3 = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p3 = spawn_server_process(&repl_env3, true).await?;
+    let mut follower_p3 = spawn_server_process(&repl_env3, true)?;
     processes.push(&mut follower_p3);
 
     // THEN - some of the followers will have hop_count 1 and some will have hop_count 0
     let res =
-        check_internodes_communication(&mut processes, DEFAULT_HOP_COUNT + 1, TIMEOUT_IN_MILLIS)
-            .await;
+        check_internodes_communication(&mut processes, DEFAULT_HOP_COUNT + 1, TIMEOUT_IN_MILLIS);
     assert!(res.is_ok());
 
     Ok(())
 }
 
-async fn run_heartbeat_hop_count_starts_with_0(with_append_only: bool) -> anyhow::Result<()> {
+fn run_heartbeat_hop_count_starts_with_0(with_append_only: bool) -> anyhow::Result<()> {
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
 
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
 
     // WHEN
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&repl_env, true).await?;
+    let mut follower_p1 = spawn_server_process(&repl_env, true)?;
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&repl_env2, true).await?;
+    let mut follower_p2 = spawn_server_process(&repl_env2, true)?;
 
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
     // THEN
 
-    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).await?;
+    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)?;
 
     // no node should have hop_count 1
-    let res =
-        check_internodes_communication(processes, DEFAULT_HOP_COUNT + 1, TIMEOUT_IN_MILLIS).await;
+    let res = check_internodes_communication(processes, DEFAULT_HOP_COUNT + 1, TIMEOUT_IN_MILLIS);
     assert!(res.is_err());
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
-    run_heartbeat_hop_count_decreases_over_time(false).await?;
-    run_heartbeat_hop_count_decreases_over_time(true).await?;
+#[test]
+fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
+    run_heartbeat_hop_count_decreases_over_time(false)?;
+    run_heartbeat_hop_count_decreases_over_time(true)?;
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
-    run_heartbeat_hop_count_starts_with_0(false).await?;
-    run_heartbeat_hop_count_starts_with_0(true).await?;
+#[test]
+fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
+    run_heartbeat_hop_count_starts_with_0(false)?;
+    run_heartbeat_hop_count_starts_with_0(true)?;
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_heartbeat.rs
+++ b/duva/tests/cluster_ops/test_heartbeat.rs
@@ -1,6 +1,7 @@
 //! This file contains tests for heartbeat between leader and follower
 //! Any interconnected system should have a heartbeat mechanism to ensure that the connection is still alive
 //! In this case, the server will send PING message to the follower and the follower will respond with PONG message
+
 use crate::common::{ServerEnv, check_internodes_communication, spawn_server_process};
 
 async fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow::Result<()> {
@@ -9,17 +10,17 @@ async fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> 
     // GIVEN
 
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
     let leader_bind_addr = leader_p.bind_addr().clone();
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&repl_env).await?;
+    let mut follower_p1 = spawn_server_process(&repl_env, true).await?;
 
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&repl_env2).await?;
+    let mut follower_p2 = spawn_server_process(&repl_env2, true).await?;
     let mut processes = vec![&mut leader_p, &mut follower_p1, &mut follower_p2];
 
     check_internodes_communication(&mut processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)
@@ -30,7 +31,7 @@ async fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> 
     let repl_env3 = ServerEnv::default()
         .with_leader_bind_addr(leader_bind_addr.clone())
         .with_append_only(with_append_only);
-    let mut follower_p3 = spawn_server_process(&repl_env3).await?;
+    let mut follower_p3 = spawn_server_process(&repl_env3, true).await?;
     processes.push(&mut follower_p3);
 
     // THEN - some of the followers will have hop_count 1 and some will have hop_count 0
@@ -48,17 +49,17 @@ async fn run_heartbeat_hop_count_starts_with_0(with_append_only: bool) -> anyhow
 
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
 
     // WHEN
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&repl_env).await?;
+    let mut follower_p1 = spawn_server_process(&repl_env, true).await?;
     let repl_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&repl_env2).await?;
+    let mut follower_p2 = spawn_server_process(&repl_env2, true).await?;
 
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
     // THEN

--- a/duva/tests/cluster_ops/test_lazy_discovery.rs
+++ b/duva/tests/cluster_ops/test_lazy_discovery.rs
@@ -3,7 +3,7 @@ use crate::common::{Client, ServerEnv, spawn_server_process};
 async fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env1 = ServerEnv::default().with_append_only(with_append_only);
-    let mut p1 = spawn_server_process(&env1).await?;
+    let mut p1 = spawn_server_process(&env1, true).await?;
 
     let mut p1_h = Client::new(p1.port);
 
@@ -12,7 +12,7 @@ async fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<
     assert_eq!(p1_h.send_and_get("KEYS *", 2).await, vec!["0) \"key\"", "1) \"key2\""]);
 
     let env2 = ServerEnv::default().with_append_only(with_append_only);
-    let p2 = spawn_server_process(&env2).await?;
+    let p2 = spawn_server_process(&env2, true).await?;
 
     let mut p2_h = Client::new(p2.port);
     p2_h.send_and_get("set other value", 1).await;
@@ -36,7 +36,7 @@ async fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<
     let new_env_with_same_topology = ServerEnv::default()
         .with_topology_path(env1.topology_path)
         .with_append_only(with_append_only);
-    let p1 = spawn_server_process(&new_env_with_same_topology).await?;
+    let p1 = spawn_server_process(&new_env_with_same_topology, true).await?;
 
     let mut p1_h = Client::new(p1.port);
     assert_eq!(p1_h.send_and_get("get key", 1).await, vec!["(nil)"]);

--- a/duva/tests/cluster_ops/test_lazy_discovery.rs
+++ b/duva/tests/cluster_ops/test_lazy_discovery.rs
@@ -1,56 +1,56 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<()> {
+fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env1 = ServerEnv::default().with_append_only(with_append_only);
-    let mut p1 = spawn_server_process(&env1, true).await?;
+    let mut p1 = spawn_server_process(&env1, true)?;
 
     let mut p1_h = Client::new(p1.port);
 
-    p1_h.send_and_get("set key 1", 1).await;
-    p1_h.send_and_get("set key2 2", 1).await;
-    assert_eq!(p1_h.send_and_get("KEYS *", 2).await, vec!["0) \"key\"", "1) \"key2\""]);
+    p1_h.send_and_get("set key 1", 1);
+    p1_h.send_and_get("set key2 2", 1);
+    assert_eq!(p1_h.send_and_get("KEYS *", 2), vec!["0) \"key\"", "1) \"key2\""]);
 
     let env2 = ServerEnv::default().with_append_only(with_append_only);
-    let p2 = spawn_server_process(&env2, true).await?;
+    let p2 = spawn_server_process(&env2, true)?;
 
     let mut p2_h = Client::new(p2.port);
-    p2_h.send_and_get("set other value", 1).await;
-    p2_h.send_and_get("set other2 value2", 1).await;
-    assert_eq!(p2_h.send_and_get("KEYS *", 2).await, vec!["0) \"other2\"", "1) \"other\""]);
+    p2_h.send_and_get("set other value", 1);
+    p2_h.send_and_get("set other2 value2", 1);
+    assert_eq!(p2_h.send_and_get("KEYS *", 2), vec!["0) \"other2\"", "1) \"other\""]);
 
     // WHEN
     assert_eq!(
-        p1_h.send_and_get(format!("REPLICAOF 127.0.0.1 {}", &env2.port), 1).await,
+        p1_h.send_and_get(format!("REPLICAOF 127.0.0.1 {}", &env2.port), 1),
         ["OK".to_string(),]
     );
 
     // TODO(dpark): Would there be a way to perform a closed-loop wait?
 
     // THEN
-    assert_eq!(p1_h.send_and_get("role", 1).await, vec!["follower"]);
-    assert_eq!(p2_h.send_and_get("role", 1).await, vec!["leader"]);
+    assert_eq!(p1_h.send_and_get("role", 1), vec!["follower"]);
+    assert_eq!(p2_h.send_and_get("role", 1), vec!["leader"]);
 
     // * Following is required to test replicaof successuflly update topology changes
-    p1.terminate().await?;
+    p1.terminate()?;
     let new_env_with_same_topology = ServerEnv::default()
         .with_topology_path(env1.topology_path)
         .with_append_only(with_append_only);
-    let p1 = spawn_server_process(&new_env_with_same_topology, true).await?;
+    let p1 = spawn_server_process(&new_env_with_same_topology, true)?;
 
     let mut p1_h = Client::new(p1.port);
-    assert_eq!(p1_h.send_and_get("get key", 1).await, vec!["(nil)"]);
-    assert_eq!(p1_h.send_and_get("get key2", 1).await, vec!["(nil)"]);
-    assert_eq!(p1_h.send_and_get("get other", 1).await, vec!["value"]);
-    assert_eq!(p1_h.send_and_get("get other2", 1).await, vec!["value2"]);
+    assert_eq!(p1_h.send_and_get("get key", 1), vec!["(nil)"]);
+    assert_eq!(p1_h.send_and_get("get key2", 1), vec!["(nil)"]);
+    assert_eq!(p1_h.send_and_get("get other", 1), vec!["value"]);
+    assert_eq!(p1_h.send_and_get("get other2", 1), vec!["value2"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_lazy_discovery_of_leader() -> anyhow::Result<()> {
-    run_lazy_discovery_of_leader(false).await?;
-    run_lazy_discovery_of_leader(true).await?;
+#[test]
+fn test_lazy_discovery_of_leader() -> anyhow::Result<()> {
+    run_lazy_discovery_of_leader(false)?;
+    run_lazy_discovery_of_leader(true)?;
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
+++ b/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
@@ -1,62 +1,62 @@
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()> {
+fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env1 = ServerEnv::default().with_append_only(with_append_only);
-    let mut p1 = spawn_server_process(&env1, true).await?;
+    let mut p1 = spawn_server_process(&env1, true)?;
 
     let env2 = ServerEnv::default()
         .with_leader_bind_addr(p1.bind_addr())
         .with_append_only(with_append_only);
-    let mut p2 = spawn_server_process(&env2, true).await?;
+    let mut p2 = spawn_server_process(&env2, true)?;
 
-    p2.wait_for_message(&p1.heartbeat_msg(0)).await?;
-    p1.wait_for_message(&p2.heartbeat_msg(0)).await?;
+    p2.wait_for_message(&p1.heartbeat_msg(0))?;
+    p1.wait_for_message(&p2.heartbeat_msg(0))?;
 
     // Set some values
     let mut cli_to_p1 = Client::new(p1.port);
-    cli_to_p1.send_and_get("SET x value1".as_bytes(), 1).await;
-    cli_to_p1.send_and_get("SET y value2".as_bytes(), 1).await;
-    cli_to_p1.send_and_get("SET z value3".as_bytes(), 1).await;
+    cli_to_p1.send_and_get("SET x value1".as_bytes(), 1);
+    cli_to_p1.send_and_get("SET y value2".as_bytes(), 1);
+    cli_to_p1.send_and_get("SET z value3".as_bytes(), 1);
     drop(cli_to_p1);
 
-    p2.kill().await?;
+    p2.kill()?;
     // WHEN running repl without p1 bind address
     let env2 = ServerEnv::default()
         .with_topology_path(env2.topology_path)
         .with_append_only(with_append_only);
 
-    p2 = spawn_server_process(&env2, true).await?;
+    p2 = spawn_server_process(&env2, true)?;
 
     //THEN
 
-    p2.wait_for_message(&p1.heartbeat_msg(0)).await?;
-    p1.wait_for_message(&p2.heartbeat_msg(0)).await?;
+    p2.wait_for_message(&p1.heartbeat_msg(0))?;
+    p1.wait_for_message(&p2.heartbeat_msg(0))?;
     let mut cli_to_p2 = Client::new(p2.port);
-    let p2_role = cli_to_p2.send_and_get("ROLE".as_bytes(), 1).await;
+    let p2_role = cli_to_p2.send_and_get("ROLE".as_bytes(), 1);
 
     let mut cli_to_p1 = Client::new(p1.port);
-    let p1_role = cli_to_p1.send_and_get("ROLE".as_bytes(), 1).await;
+    let p1_role = cli_to_p1.send_and_get("ROLE".as_bytes(), 1);
 
     assert_eq!(p2_role, vec!["follower".to_string()]);
     assert_eq!(p1_role, vec!["leader".to_string()]);
 
     // Check that the values are still there
-    let val = cli_to_p2.send_and_get("GET x", 1).await;
+    let val = cli_to_p2.send_and_get("GET x", 1);
     assert_eq!(val, vec!["value1"]);
-    let val = cli_to_p2.send_and_get("GET y", 1).await;
+    let val = cli_to_p2.send_and_get("GET y", 1);
     assert_eq!(val, vec!["value2"]);
 
-    let val = cli_to_p2.send_and_get("GET z", 1).await;
+    let val = cli_to_p2.send_and_get("GET z", 1);
     assert_eq!(val, vec!["value3"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_reconnection_on_reboot() -> anyhow::Result<()> {
-    run_reconnection_on_reboot(false).await?;
-    run_reconnection_on_reboot(true).await?;
+#[test]
+fn test_reconnection_on_reboot() -> anyhow::Result<()> {
+    run_reconnection_on_reboot(false)?;
+    run_reconnection_on_reboot(true)?;
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
+++ b/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
@@ -1,15 +1,14 @@
-/// issue: 297
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
 async fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env1 = ServerEnv::default().with_append_only(with_append_only);
-    let mut p1 = spawn_server_process(&env1).await?;
+    let mut p1 = spawn_server_process(&env1, true).await?;
 
     let env2 = ServerEnv::default()
         .with_leader_bind_addr(p1.bind_addr())
         .with_append_only(with_append_only);
-    let mut p2 = spawn_server_process(&env2).await?;
+    let mut p2 = spawn_server_process(&env2, true).await?;
 
     p2.wait_for_message(&p1.heartbeat_msg(0)).await?;
     p1.wait_for_message(&p2.heartbeat_msg(0)).await?;
@@ -27,7 +26,7 @@ async fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()
         .with_topology_path(env2.topology_path)
         .with_append_only(with_append_only);
 
-    p2 = spawn_server_process(&env2).await?;
+    p2 = spawn_server_process(&env2, true).await?;
 
     //THEN
 

--- a/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
+++ b/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
@@ -5,12 +5,12 @@ async fn run_removes_node_when_heartbeat_is_not_received_for_certain_time(
 ) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true).await?;
 
     repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
     leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;

--- a/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
+++ b/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
@@ -1,40 +1,42 @@
+use std::{thread::sleep, time::Duration};
+
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_removes_node_when_heartbeat_is_not_received_for_certain_time(
+fn run_removes_node_when_heartbeat_is_not_received_for_certain_time(
     with_append_only: bool,
 ) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
 
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut repl_p = spawn_server_process(&repl_env, true).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true)?;
 
-    repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
-    leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;
+    repl_p.wait_for_message(&leader_p.heartbeat_msg(0))?;
+    leader_p.wait_for_message(&repl_p.heartbeat_msg(0))?;
 
     let mut h = Client::new(leader_p.port);
     let cmd = "cluster info";
     let cluster_info = h.send_and_get(cmd, 1);
-    assert_eq!(cluster_info.await.first().unwrap(), "cluster_known_nodes:1");
+    assert_eq!(cluster_info.first().unwrap(), "cluster_known_nodes:1");
 
     // WHEN
-    repl_p.kill().await?;
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    repl_p.kill()?;
+    sleep(Duration::from_secs(2));
     let cluster_info = h.send_and_get(cmd, 1);
 
     //THEN
-    assert_eq!(cluster_info.await.first().unwrap(), "cluster_known_nodes:0");
+    assert_eq!(cluster_info.first().unwrap(), "cluster_known_nodes:0");
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_removes_node_when_heartbeat_is_not_received_for_certain_time() -> anyhow::Result<()> {
-    run_removes_node_when_heartbeat_is_not_received_for_certain_time(false).await?;
-    run_removes_node_when_heartbeat_is_not_received_for_certain_time(true).await?;
+#[test]
+fn test_removes_node_when_heartbeat_is_not_received_for_certain_time() -> anyhow::Result<()> {
+    run_removes_node_when_heartbeat_is_not_received_for_certain_time(false)?;
+    run_removes_node_when_heartbeat_is_not_received_for_certain_time(true)?;
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_leader_election.rs
+++ b/duva/tests/replication_ops/test_leader_election.rs
@@ -6,18 +6,18 @@ use duva::domains::cluster_actors::heartbeats::scheduler::LEADER_HEARTBEAT_INTER
 async fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true).await?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
 
-    let mut follower_p2 = spawn_server_process(&follower_env2).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
@@ -48,17 +48,17 @@ async fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
 async fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true).await?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&follower_env2).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
@@ -90,17 +90,17 @@ async fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<
 async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true).await?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&follower_env2).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
@@ -123,7 +123,7 @@ async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()>
         let follower_env3 = ServerEnv::default()
             .with_leader_bind_addr(f.bind_addr())
             .with_append_only(with_append_only);
-        let new_process = spawn_server_process(&follower_env3).await?;
+        let new_process = spawn_server_process(&follower_env3, true).await?;
         sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
 
         // WHEN

--- a/duva/tests/replication_ops/test_leader_election.rs
+++ b/duva/tests/replication_ops/test_leader_election.rs
@@ -1,37 +1,37 @@
-use tokio::time::{Duration, sleep};
+use std::{thread::sleep, time::Duration};
 
 use crate::common::{Client, ServerEnv, check_internodes_communication, spawn_server_process};
 use duva::domains::cluster_actors::heartbeats::scheduler::LEADER_HEARTBEAT_INTERVAL_MAX;
 
-async fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
+fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env, true).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true)?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true)?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
 
-    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true)?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
-    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).await?;
+    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)?;
 
     // WHEN
-    leader_p.kill().await?;
-    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
+    leader_p.kill()?;
+    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
 
     // THEN
     let mut flag = false;
     for f in [&follower_p1, &follower_p2] {
         let mut handler = Client::new(f.port);
-        let response1 = handler.send_and_get("info replication", 4).await;
+        let response1 = handler.send_and_get("info replication", 4);
         if response1.contains(&"role:leader".to_string()) {
             flag = true;
             break;
@@ -45,37 +45,37 @@ async fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
 // ! EDGE case : when last_log_term is not updated, after the election, first write operation succeeds but second one doesn't
 // ! This is because the leader doesn't have the last_log_term of the first write operation
 // ! This test is to see if the leader can set the value twice after the election
-async fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<()> {
+fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env, true).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true)?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true)?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true)?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
-    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).await?;
+    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)?;
 
     // WHEN
-    leader_p.kill().await?;
-    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
+    leader_p.kill()?;
+    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
 
     let mut flag = false;
     for f in [&follower_p1, &follower_p2] {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4).await;
+        let res = handler.send_and_get("info replication", 4);
         if res.contains(&"role:leader".to_string()) {
             // THEN - one of the replicas should become the leader
-            assert_eq!(handler.send_and_get("set 1 2", 1).await.first().unwrap(), "OK");
-            assert_eq!(handler.send_and_get("set 2 3", 1).await.first().unwrap(), "OK");
+            assert_eq!(handler.send_and_get("set 1 2", 1).first().unwrap(), "OK");
+            assert_eq!(handler.send_and_get("set 2 3", 1).first().unwrap(), "OK");
 
             flag = true;
             break;
@@ -87,34 +87,34 @@ async fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<
 }
 
 /// following test is to see if election works even after the first election.
-async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
+fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let leader_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut leader_p = spawn_server_process(&leader_env, true).await?;
+    let mut leader_p = spawn_server_process(&leader_env, true)?;
 
     let follower_env1 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p1 = spawn_server_process(&follower_env1, true).await?;
+    let mut follower_p1 = spawn_server_process(&follower_env1, true)?;
 
     let follower_env2 = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
-    let mut follower_p2 = spawn_server_process(&follower_env2, true).await?;
+    let mut follower_p2 = spawn_server_process(&follower_env2, true)?;
     const DEFAULT_HOP_COUNT: usize = 0;
     const TIMEOUT_IN_MILLIS: u128 = 2000;
     let processes = &mut [&mut leader_p, &mut follower_p1, &mut follower_p2];
-    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS).await?;
+    check_internodes_communication(processes, DEFAULT_HOP_COUNT, TIMEOUT_IN_MILLIS)?;
 
     // !first leader is killed -> election happens
-    leader_p.kill().await?;
-    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
+    leader_p.kill()?;
+    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
 
     let mut processes = vec![];
 
     for mut f in [follower_p1, follower_p2] {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4).await;
+        let res = handler.send_and_get("info replication", 4);
         if !res.contains(&"role:leader".to_string()) {
             processes.push(f);
             continue;
@@ -123,13 +123,13 @@ async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()>
         let follower_env3 = ServerEnv::default()
             .with_leader_bind_addr(f.bind_addr())
             .with_append_only(with_append_only);
-        let new_process = spawn_server_process(&follower_env3, true).await?;
-        sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
+        let new_process = spawn_server_process(&follower_env3, true)?;
+        sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
 
         // WHEN
         // ! second leader is killed -> election happens
-        f.kill().await?;
-        sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX)).await;
+        f.kill()?;
+        sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
         processes.push(new_process);
     }
     assert_eq!(processes.len(), 2);
@@ -137,7 +137,7 @@ async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()>
     let mut flag = false;
     for f in processes.iter() {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4).await;
+        let res = handler.send_and_get("info replication", 4);
         if res.contains(&"role:leader".to_string()) {
             flag = true;
             break;
@@ -148,26 +148,26 @@ async fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()>
     Ok(())
 }
 
-#[tokio::test]
-async fn test_leader_election() -> anyhow::Result<()> {
-    run_leader_election(false).await?;
-    run_leader_election(true).await?;
+#[test]
+fn test_leader_election() -> anyhow::Result<()> {
+    run_leader_election(false)?;
+    run_leader_election(true)?;
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_set_twice_after_election() -> anyhow::Result<()> {
-    run_set_twice_after_election(false).await?;
-    run_set_twice_after_election(true).await?;
+#[test]
+fn test_set_twice_after_election() -> anyhow::Result<()> {
+    run_set_twice_after_election(false)?;
+    run_set_twice_after_election(true)?;
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_leader_election_twice() -> anyhow::Result<()> {
-    run_leader_election_twice(false).await?;
-    run_leader_election_twice(true).await?;
+#[test]
+fn test_leader_election_twice() -> anyhow::Result<()> {
+    run_leader_election_twice(false)?;
+    run_leader_election_twice(true)?;
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_raft_happy_case.rs
+++ b/duva/tests/replication_ops/test_raft_happy_case.rs
@@ -1,15 +1,15 @@
-use std::time::Duration;
+use std::{thread::sleep, time::Duration};
 
 use duva::domains::cluster_actors::heartbeats::scheduler::LEADER_HEARTBEAT_INTERVAL_MAX;
 
 use crate::common::{Client, ServerEnv, spawn_server_process};
 
-async fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> anyhow::Result<()> {
+fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
 
     // loads the leader/follower processes
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
     let mut client_handler = Client::new(leader_p.port);
 
     let repl_env = ServerEnv::default()
@@ -17,28 +17,28 @@ async fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> an
         .with_file_name("follower_dbfilename")
         .with_append_only(with_append_only);
 
-    let mut repl_p = spawn_server_process(&repl_env, true).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true)?;
 
-    repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
-    leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;
+    repl_p.wait_for_message(&leader_p.heartbeat_msg(0))?;
+    leader_p.wait_for_message(&repl_p.heartbeat_msg(0))?;
 
     // WHEN -- set operation is made
-    client_handler.send_and_get("SET foo bar", 1).await;
+    client_handler.send_and_get("SET foo bar", 1);
 
     //THEN
-    tokio::time::sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX * 2)).await;
+    sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX * 2));
 
     let mut client = Client::new(repl_p.port);
-    let res = client.send_and_get("GET foo", 1).await;
+    let res = client.send_and_get("GET foo", 1);
     assert_eq!(res, vec!["bar"]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_set_operation_reaches_to_all_replicas() -> anyhow::Result<()> {
-    run_set_operation_reaches_to_all_replicas(false).await?;
-    run_set_operation_reaches_to_all_replicas(true).await?;
+#[test]
+fn test_set_operation_reaches_to_all_replicas() -> anyhow::Result<()> {
+    run_set_operation_reaches_to_all_replicas(false)?;
+    run_set_operation_reaches_to_all_replicas(true)?;
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_raft_happy_case.rs
+++ b/duva/tests/replication_ops/test_raft_happy_case.rs
@@ -9,7 +9,7 @@ async fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> an
     let env = ServerEnv::default().with_append_only(with_append_only);
 
     // loads the leader/follower processes
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
     let mut client_handler = Client::new(leader_p.port);
 
     let repl_env = ServerEnv::default()
@@ -17,7 +17,7 @@ async fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> an
         .with_file_name("follower_dbfilename")
         .with_append_only(with_append_only);
 
-    let mut repl_p = spawn_server_process(&repl_env).await?;
+    let mut repl_p = spawn_server_process(&repl_env, true).await?;
 
     repl_p.wait_for_message(&leader_p.heartbeat_msg(0)).await?;
     leader_p.wait_for_message(&repl_p.heartbeat_msg(0)).await?;

--- a/duva/tests/replication_ops/test_sync.rs
+++ b/duva/tests/replication_ops/test_sync.rs
@@ -5,7 +5,7 @@ async fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow:
     let env = ServerEnv::default().with_append_only(with_append_only);
 
     // Start the leader server as a child process
-    let mut leader_p = spawn_server_process(&env).await?;
+    let mut leader_p = spawn_server_process(&env, true).await?;
     let mut h = Client::new(leader_p.port);
 
     h.send_and_get("SET foo bar", 1).await;
@@ -15,7 +15,7 @@ async fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow:
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
 
-    let mut replica_process = spawn_server_process(&repl_env).await?;
+    let mut replica_process = spawn_server_process(&repl_env, true).await?;
     check_internodes_communication(&mut [&mut leader_p, &mut replica_process], 0, 1000).await?;
 
     // THEN

--- a/duva/tests/replication_ops/test_sync.rs
+++ b/duva/tests/replication_ops/test_sync.rs
@@ -1,34 +1,34 @@
 use crate::common::{Client, ServerEnv, check_internodes_communication, spawn_server_process};
 
-async fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow::Result<()> {
+fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
     let env = ServerEnv::default().with_append_only(with_append_only);
 
     // Start the leader server as a child process
-    let mut leader_p = spawn_server_process(&env, true).await?;
+    let mut leader_p = spawn_server_process(&env, true)?;
     let mut h = Client::new(leader_p.port);
 
-    h.send_and_get("SET foo bar", 1).await;
+    h.send_and_get("SET foo bar", 1);
 
     // WHEN run replica
     let repl_env = ServerEnv::default()
         .with_leader_bind_addr(leader_p.bind_addr())
         .with_append_only(with_append_only);
 
-    let mut replica_process = spawn_server_process(&repl_env, true).await?;
-    check_internodes_communication(&mut [&mut leader_p, &mut replica_process], 0, 1000).await?;
+    let mut replica_process = spawn_server_process(&repl_env, true)?;
+    check_internodes_communication(&mut [&mut leader_p, &mut replica_process], 0, 1000)?;
 
     // THEN
     let mut client_to_repl = Client::new(replica_process.port);
-    assert_eq!(client_to_repl.send_and_get("KEYS *", 1).await, vec!["0) \"foo\""]);
+    assert_eq!(client_to_repl.send_and_get("KEYS *", 1), vec!["0) \"foo\""]);
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
-    run_full_sync_on_newly_added_replica(false).await?;
-    run_full_sync_on_newly_added_replica(true).await?;
+#[test]
+fn test_full_sync_on_newly_added_replica() -> anyhow::Result<()> {
+    run_full_sync_on_newly_added_replica(false)?;
+    run_full_sync_on_newly_added_replica(true)?;
 
     Ok(())
 }


### PR DESCRIPTION
The changes made from this [PR](https://github.com/Migorithm/duva/pull/498) causes zombie processes springing up. 

Turns out, `terminate` wasn't triggered and in the review process it was overlooked / missed. 


