### PR TITLE
test: cnt not requiring helper method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,8 +342,10 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "libc",
  "memchr",
  "memmap2",
+ "nix 0.30.1",
  "rand",
  "regex",
  "tempfile",
@@ -609,9 +611,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -702,6 +704,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -949,7 +963,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.29.0",
  "radix_trie",
  "rusqlite",
  "rustyline-derive",

--- a/duva/Cargo.toml
+++ b/duva/Cargo.toml
@@ -25,3 +25,5 @@ tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
 tempfile = "3.19.1"
+nix = { version = "0.30.1", features = ["poll"] }
+libc = "0.2"

--- a/duva/src/presentation/clients/stream.rs
+++ b/duva/src/presentation/clients/stream.rs
@@ -8,7 +8,7 @@ use tokio::{
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
     sync::mpsc::Sender,
 };
-use tracing::{error, instrument, warn};
+use tracing::{error, instrument};
 use uuid::Uuid;
 pub struct ClientStreamReader {
     pub(crate) r: OwnedReadHalf,

--- a/duva/tests/client_ops/test_append.rs
+++ b/duva/tests/client_ops/test_append.rs
@@ -16,22 +16,19 @@ fn test_append() -> anyhow::Result<()> {
     let second = "World!";
 
     // WHEN - append first value
-    assert_eq!(
-        h.send_and_get(format!("APPEND appended_one {first}"), 1),
-        vec![first.len().to_string()]
-    );
+    assert_eq!(h.send_and_get(format!("APPEND appended_one {first}")), first.len().to_string());
     // THEN
-    let res = h.send_and_get("GET appended_one", 1);
-    assert_eq!(res, vec!["Hello"]);
+    let res = h.send_and_get("GET appended_one");
+    assert_eq!(res, "Hello");
 
     // WHEN - append second value
     assert_eq!(
-        h.send_and_get(format!("APPEND appended_one {second}"), 1),
-        vec![(first.len() + second.len()).to_string()]
+        h.send_and_get(format!("APPEND appended_one {second}")),
+        (first.len() + second.len()).to_string()
     );
     // THEN
-    let res = h.send_and_get("GET appended_one", 1);
-    assert_eq!(res, vec!["HelloWorld!"]);
+    let res = h.send_and_get("GET appended_one");
+    assert_eq!(res, "HelloWorld!");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_config_get_dir.rs
+++ b/duva/tests/client_ops/test_config_get_dir.rs
@@ -12,10 +12,10 @@ fn run_config_get_dir(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN
-    let res = h.send_and_get("CONFIG get dir", 1);
+    let res = h.send_and_get("CONFIG get dir");
 
     // THEN
-    assert_eq!(res.first().unwrap(), &format!("dir {}", env.dir.path().display()));
+    assert_eq!(res, format!("dir {}", env.dir.path().display()));
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_decr.rs
+++ b/duva/tests/client_ops/test_decr.rs
@@ -1,4 +1,4 @@
-use crate::common::{Client, ServerEnv, form_cluster, spawn_server_process};
+use crate::common::{Client, ServerEnv, form_cluster};
 
 fn run_decr(with_append_only: bool) -> anyhow::Result<()> {
     // GIVEN
@@ -11,34 +11,28 @@ fn run_decr(with_append_only: bool) -> anyhow::Result<()> {
     let mut h2: Client = Client::new(follower_p.port);
 
     // WHEN & THEN - happy case
-    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -1"]);
-    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -2"]);
-    assert_eq!(h.send_and_get("DECR a", 1), vec!["(integer) -3"]);
-    assert_eq!(h.send_and_get("GET a", 1), vec!["-3"]);
+    assert_eq!(h.send_and_get("DECR a"), "(integer) -1");
+    assert_eq!(h.send_and_get("DECR a"), "(integer) -2");
+    assert_eq!(h.send_and_get("DECR a"), "(integer) -3");
+    assert_eq!(h.send_and_get("GET a"), "-3");
 
     // THEN & THEN - increase and decrease
-    assert_eq!(h.send_and_get("INCR b", 1), vec!["(integer) 1"]);
-    assert_eq!(h.send_and_get("DECR b", 1), vec!["(integer) 0"]);
+    assert_eq!(h.send_and_get("INCR b"), "(integer) 1");
+    assert_eq!(h.send_and_get("DECR b"), "(integer) 0");
 
     // WHEN & THEN- operation on string
-    assert_eq!(h.send_and_get("SET c adsds", 1), vec!["OK"]);
-    assert_eq!(
-        h.send_and_get("DECR c", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("SET c adsds"), "OK");
+    assert_eq!(h.send_and_get("DECR c"), "(error) ERR value is not an integer or out of range");
 
     // WHEN & THEN- out of range
-    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1), vec!["OK"]);
-    assert_eq!(
-        h.send_and_get("DECR d", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("SET d 92233720368547332375808"), "OK");
+    assert_eq!(h.send_and_get("DECR d"), "(error) ERR value is not an integer or out of range");
 
     // WHEN & THEN- getting values from follower
-    assert_eq!(h2.send_and_get("GET a", 1), vec!["-3"]);
-    assert_eq!(h2.send_and_get("GET b", 1), vec!["0"]);
-    assert_eq!(h2.send_and_get("GET c", 1), vec!["adsds"]);
-    assert_eq!(h2.send_and_get("GET d", 1), vec!["92233720368547332375808"]);
+    assert_eq!(h2.send_and_get("GET a"), "-3");
+    assert_eq!(h2.send_and_get("GET b"), "0");
+    assert_eq!(h2.send_and_get("GET c"), "adsds");
+    assert_eq!(h2.send_and_get("GET d"), "92233720368547332375808");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_decrby.rs
+++ b/duva/tests/client_ops/test_decrby.rs
@@ -6,35 +6,32 @@ fn run_decrby(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN: Basic decrement
-    assert_eq!(h.send_and_get("SET a 10", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("DECRBY a 5", 1), vec!["(integer) 5"]);
+    assert_eq!(h.send_and_get("SET a 10"), "OK");
+    assert_eq!(h.send_and_get("DECRBY a 5"), "(integer) 5");
 
     // THEN
-    assert_eq!(h.send_and_get("GET a", 1), vec!["5"]);
+    assert_eq!(h.send_and_get("GET a"), "5");
 
     // WHEN: Decrement existing value
-    assert_eq!(h.send_and_get("SET b 10", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("DECRBY b 5", 1), vec!["(integer) 5"]);
-    assert_eq!(h.send_and_get("DECRBY b 5", 1), vec!["(integer) 0"]);
+    assert_eq!(h.send_and_get("SET b 10"), "OK");
+    assert_eq!(h.send_and_get("DECRBY b 5"), "(integer) 5");
+    assert_eq!(h.send_and_get("DECRBY b 5"), "(integer) 0");
 
     // THEN
-    assert_eq!(h.send_and_get("GET b", 1), vec!["0"]);
+    assert_eq!(h.send_and_get("GET b"), "0");
 
     // WHEN: Try to decrement non-integer value
-    assert_eq!(h.send_and_get("SET c not_a_number", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c not_a_number"), "OK");
 
     // THEN
-    assert_eq!(
-        h.send_and_get("DECRBY c 1", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("DECRBY c 1"), "(error) ERR value is not an integer or out of range");
 
     // WHEN: Decrement with negative value (should increment)
-    assert_eq!(h.send_and_get("SET d 5", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("DECRBY d -3", 1), vec!["(integer) 8"]);
+    assert_eq!(h.send_and_get("SET d 5"), "OK");
+    assert_eq!(h.send_and_get("DECRBY d -3"), "(integer) 8");
 
     // THEN
-    assert_eq!(h.send_and_get("GET d", 1), vec!["8"]);
+    assert_eq!(h.send_and_get("GET d"), "8");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_del.rs
+++ b/duva/tests/client_ops/test_del.rs
@@ -9,17 +9,17 @@ fn run_del(env: ServerEnv) -> anyhow::Result<()> {
     let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
-    assert_eq!(h.send_and_get("SET a b", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("SET c d", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET a b"), "OK");
+    assert_eq!(h.send_and_get("SET c d"), "OK");
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("del a c d", 1), vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("del a c d"), "(integer) 2");
 
-    assert_eq!(h.send_and_get("get a", 1), vec!["(nil)"]);
+    assert_eq!(h.send_and_get("get a"), "(nil)");
 
     // THEN
-    let res = h.send_and_get("GET somanyrand", 1);
-    assert_eq!(res, vec!["(nil)"]);
+    let res = h.send_and_get("GET somanyrand");
+    assert_eq!(res, "(nil)");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_exists.rs
+++ b/duva/tests/client_ops/test_exists.rs
@@ -9,14 +9,14 @@ fn run_exists(env: ServerEnv) -> anyhow::Result<()> {
     let process = spawn_server_process(&env, false)?;
 
     let mut h = Client::new(process.port);
-    assert_eq!(h.send_and_get("SET a b", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET a b"), "OK");
 
-    assert_eq!(h.send_and_get("SET c d", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c d"), "OK");
 
     // WHEN & THEN
-    assert_eq!(h.send_and_get("exists a c d", 1), vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("exists a c d"), "(integer) 2");
 
-    assert_eq!(h.send_and_get("exists x", 1), vec!["(integer) 0"]);
+    assert_eq!(h.send_and_get("exists x"), "(integer) 0");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_incr.rs
+++ b/duva/tests/client_ops/test_incr.rs
@@ -11,28 +11,22 @@ fn run_incr(with_append_only: bool) -> anyhow::Result<()> {
     let mut h2 = Client::new(follower_p.port);
 
     // WHEN & THEN
-    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 1"]);
-    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 2"]);
-    assert_eq!(h.send_and_get("INCR a", 1), vec!["(integer) 3"]);
-    assert_eq!(h.send_and_get("GET a", 1), vec!["3"]);
+    assert_eq!(h.send_and_get("INCR a"), "(integer) 1");
+    assert_eq!(h.send_and_get("INCR a"), "(integer) 2");
+    assert_eq!(h.send_and_get("INCR a"), "(integer) 3");
+    assert_eq!(h.send_and_get("GET a"), "3");
 
     // WHEN & THEN- set a string and apply incr on the same key
-    assert_eq!(h.send_and_get("SET c adsds", 1), vec!["OK"]);
-    assert_eq!(
-        h.send_and_get("INCR c", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("SET c adsds"), "OK");
+    assert_eq!(h.send_and_get("INCR c"), "(error) ERR value is not an integer or out of range");
 
     // WHEN - out of range
-    assert_eq!(h.send_and_get("SET d 92233720368547332375808", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET d 92233720368547332375808"), "OK");
     // THEN
-    assert_eq!(
-        h.send_and_get("INCR d", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("INCR d"), "(error) ERR value is not an integer or out of range");
 
     // WHEN&THEN- getting values from follower
-    assert_eq!(h2.send_and_get("GET a", 1), vec!["3"]);
+    assert_eq!(h2.send_and_get("GET a"), "3");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_incrby.rs
+++ b/duva/tests/client_ops/test_incrby.rs
@@ -6,35 +6,32 @@ fn run_incrby(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN: Basic increment
-    assert_eq!(h.send_and_get("SET a 10", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("INCRBY a 5", 1), vec!["(integer) 15"]);
+    assert_eq!(h.send_and_get("SET a 10"), "OK");
+    assert_eq!(h.send_and_get("INCRBY a 5"), "(integer) 15");
 
     // THEN
-    assert_eq!(h.send_and_get("GET a", 1), vec!["15"]);
+    assert_eq!(h.send_and_get("GET a"), "15");
 
     // WHEN: Increment existing value
-    assert_eq!(h.send_and_get("SET b 10", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("INCRBY b 5", 1), vec!["(integer) 15"]);
-    assert_eq!(h.send_and_get("INCRBY b 5", 1), vec!["(integer) 20"]);
+    assert_eq!(h.send_and_get("SET b 10"), "OK");
+    assert_eq!(h.send_and_get("INCRBY b 5"), "(integer) 15");
+    assert_eq!(h.send_and_get("INCRBY b 5"), "(integer) 20");
 
     // THEN
-    assert_eq!(h.send_and_get("GET b", 1), vec!["20"]);
+    assert_eq!(h.send_and_get("GET b"), "20");
 
     // WHEN: Try to increment non-integer value
-    assert_eq!(h.send_and_get("SET c not_a_number", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET c not_a_number"), "OK");
 
     // THEN
-    assert_eq!(
-        h.send_and_get("INCRBY c 1", 1),
-        vec!["(error) ERR value is not an integer or out of range"]
-    );
+    assert_eq!(h.send_and_get("INCRBY c 1"), "(error) ERR value is not an integer or out of range");
 
     // WHEN: Increment with negative value (should decrement)
-    assert_eq!(h.send_and_get("SET d 5", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("INCRBY d -3", 1), vec!["(integer) 2"]);
+    assert_eq!(h.send_and_get("SET d 5"), "OK");
+    assert_eq!(h.send_and_get("INCRBY d -3"), "(integer) 2");
 
     // THEN
-    assert_eq!(h.send_and_get("GET d", 1), vec!["2"]);
+    assert_eq!(h.send_and_get("GET d"), "2");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_keys.rs
+++ b/duva/tests/client_ops/test_keys.rs
@@ -10,11 +10,11 @@ fn run_keys(env: ServerEnv) -> anyhow::Result<()> {
 
     // WHEN set 500 keys with the value `bar`.
     for key in 0..num_keys_to_store {
-        h.send_and_get(format!("SET {} bar", key), 1);
+        h.send_and_get(format!("SET {} bar", key));
     }
 
     // Fire keys command
-    let res = h.send_and_get("KEYS *", num_keys_to_store);
+    let res = h.send_and_get_vec("KEYS *", num_keys_to_store);
 
     assert!(res.len() >= num_keys_to_store as usize);
 

--- a/duva/tests/client_ops/test_replication_info.rs
+++ b/duva/tests/client_ops/test_replication_info.rs
@@ -10,7 +10,7 @@ fn run_replication_info(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN
-    let res = h.send_and_get("INFO replication", 4);
+    let res = h.send_and_get_vec("INFO replication", 4);
 
     // THEN
     assert_eq!(res[0], "role:leader");

--- a/duva/tests/client_ops/test_set_get.rs
+++ b/duva/tests/client_ops/test_set_get.rs
@@ -11,15 +11,15 @@ fn run_set_get(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("SET somanyrand bar PX 300", 1), vec!["OK"]);
-    let res = h.send_and_get("GET somanyrand", 1);
-    assert_eq!(res, vec!["bar"]);
+    assert_eq!(h.send_and_get("SET somanyrand bar PX 300"), "OK");
+    let res = h.send_and_get("GET somanyrand");
+    assert_eq!(res, "bar");
 
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     // THEN
-    let res = h.send_and_get("GET somanyrand", 1);
-    assert_eq!(res, vec!["(nil)"]);
+    let res = h.send_and_get("GET somanyrand");
+    assert_eq!(res, "(nil)");
 
     Ok(())
 }

--- a/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
+++ b/duva/tests/client_ops/test_snapshot_persists_and_recovers_state.rs
@@ -10,16 +10,16 @@ fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Result<()
     let mut h = Client::new(leader_process.port);
 
     // WHEN
-    let res = h.send_and_get("SET foo bar", 1);
-    assert_eq!(res, vec!["OK"]);
-    assert_eq!(h.send_and_get("SET foo2 bar2 PX 9999999999", 1), vec!["OK"]);
-    assert_eq!(h.send_and_get("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
+    let res = h.send_and_get("SET foo bar");
+    assert_eq!(res, "OK");
+    assert_eq!(h.send_and_get("SET foo2 bar2 PX 9999999999"), "OK");
+    assert_eq!(h.send_and_get_vec("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
 
     // pre load replication info for comparison
-    let old_info = h.send_and_get("INFO replication", 4);
+    let old_info = h.send_and_get_vec("INFO replication", 4);
 
     // WHEN
-    assert_eq!(h.send_and_get("SAVE", 1), vec!["(nil)"]);
+    assert_eq!(h.send_and_get("SAVE"), "(nil)");
 
     // kill leader process
     let _ = leader_process.terminate();
@@ -28,10 +28,10 @@ fn run_snapshot_persists_and_recovers_state(env: ServerEnv) -> anyhow::Result<()
     let new_process = spawn_server_process(&env, false)?;
 
     let mut client = Client::new(new_process.port);
-    assert_eq!(client.send_and_get("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
+    assert_eq!(client.send_and_get_vec("KEYS *", 2), vec!["0) \"foo2\"", "1) \"foo\""]);
 
     // replication info
-    let new_info = client.send_and_get("INFO replication", 4);
+    let new_info = client.send_and_get_vec("INFO replication", 4);
 
     // THEN
     assert_eq!(old_info, new_info);

--- a/duva/tests/client_ops/test_ttl.rs
+++ b/duva/tests/client_ops/test_ttl.rs
@@ -7,13 +7,13 @@ fn run_ttl(env: ServerEnv) -> anyhow::Result<()> {
     let mut h = Client::new(process.port);
 
     // WHEN - set key with expiry
-    assert_eq!(h.send_and_get("SET somanyrand bar PX 5000", 1), vec!["OK"]);
+    assert_eq!(h.send_and_get("SET somanyrand bar PX 5000"), "OK");
     std::thread::sleep(tokio::time::Duration::from_millis(10)); // slight delay so seconds gets floored
-    let res = h.send_and_get("TTL somanyrand", 1);
+    let res = h.send_and_get("TTL somanyrand");
 
     // THEN
-    assert_eq!(res, vec!["(integer) 4"]);
-    assert_eq!(h.send_and_get("TTL non_existing_key", 1), vec!["(integer) -1"]);
+    assert_eq!(res, "(integer) 4");
+    assert_eq!(h.send_and_get("TTL non_existing_key"), "(integer) -1");
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_makes_all_nodes_forget_target_node.rs
@@ -16,18 +16,18 @@ fn run_cluster_forget_makes_all_nodes_forget_target_node(
     // WHEN
     let mut client_handler = Client::new(leader_p.port);
     assert_eq!(
-        client_handler.send_and_get(format!("cluster forget {}", &repl_p.bind_addr()), 1),
-        vec!["OK"]
+        client_handler.send_and_get(format!("cluster forget {}", &repl_p.bind_addr())),
+        "OK"
     );
 
     // THEN
-    assert_eq!(client_handler.send_and_get("cluster info", 1), vec!["cluster_known_nodes:1"]);
+    assert_eq!(client_handler.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:1"]);
 
     let mut repl_cli = Client::new(repl_p2.port);
 
     std::thread::sleep(std::time::Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX + 1));
 
-    assert_eq!(repl_cli.send_and_get("cluster info", 1), vec!["cluster_known_nodes:1"]);
+    assert_eq!(repl_cli.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:1"]);
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
+++ b/duva/tests/cluster_ops/test_cluster_forget_when_wrong_id_given.rs
@@ -12,10 +12,10 @@ fn run_cluster_forget_node_return_error_when_wrong_id_given(env: ServerEnv) -> a
     let cmd = format!("cluster forget {}", &replica_id);
 
     // THEN
-    assert_eq!(client_handler.send_and_get(&cmd, 1), vec!["(error) No such peer"]);
+    assert_eq!(client_handler.send_and_get(&cmd), "(error) No such peer");
 
     // WHEN & THEN
-    assert_eq!(client_handler.send_and_get("cluster info", 1), vec!["cluster_known_nodes:0"]);
+    assert_eq!(client_handler.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:0"]);
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
+++ b/duva/tests/cluster_ops/test_cluster_known_nodes_increase_when_new_replica_is_added.rs
@@ -10,7 +10,7 @@ fn run_cluster_topology_change_when_new_node_added(with_append_only: bool) -> an
 
     let mut client_handler = Client::new(leader_p.port);
     assert_eq!(
-        client_handler.send_and_get("cluster info", 1),
+        client_handler.send_and_get_vec("cluster info", 1),
         vec!["cluster_known_nodes:1".to_string()]
     );
 
@@ -23,10 +23,10 @@ fn run_cluster_topology_change_when_new_node_added(with_append_only: bool) -> an
 
     //THEN
     assert_eq!(
-        client_handler.send_and_get("cluster info", 1),
+        client_handler.send_and_get_vec("cluster info", 1),
         vec!["cluster_known_nodes:2".to_string()]
     );
-    let nodes = client_handler.send_and_get("cluster nodes", 3);
+    let nodes = client_handler.send_and_get_vec("cluster nodes", 3);
     assert_eq!(nodes.len(), 3);
     std::fs::read_to_string(&env.topology_path)
         .unwrap()

--- a/duva/tests/cluster_ops/test_lazy_discovery.rs
+++ b/duva/tests/cluster_ops/test_lazy_discovery.rs
@@ -7,29 +7,29 @@ fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<()> {
 
     let mut p1_h = Client::new(p1.port);
 
-    p1_h.send_and_get("set key 1", 1);
-    p1_h.send_and_get("set key2 2", 1);
-    assert_eq!(p1_h.send_and_get("KEYS *", 2), vec!["0) \"key\"", "1) \"key2\""]);
+    p1_h.send_and_get_vec("set key 1", 1);
+    p1_h.send_and_get_vec("set key2 2", 1);
+    assert_eq!(p1_h.send_and_get_vec("KEYS *", 2), vec!["0) \"key\"", "1) \"key2\""]);
 
     let env2 = ServerEnv::default().with_append_only(with_append_only);
     let p2 = spawn_server_process(&env2, false)?;
 
     let mut p2_h = Client::new(p2.port);
-    p2_h.send_and_get("set other value", 1);
-    p2_h.send_and_get("set other2 value2", 1);
-    assert_eq!(p2_h.send_and_get("KEYS *", 2), vec!["0) \"other2\"", "1) \"other\""]);
+    p2_h.send_and_get_vec("set other value", 1);
+    p2_h.send_and_get_vec("set other2 value2", 1);
+    assert_eq!(p2_h.send_and_get_vec("KEYS *", 2), vec!["0) \"other2\"", "1) \"other\""]);
 
     // WHEN
     assert_eq!(
-        p1_h.send_and_get(format!("REPLICAOF 127.0.0.1 {}", &env2.port), 1),
+        p1_h.send_and_get_vec(format!("REPLICAOF 127.0.0.1 {}", &env2.port), 1),
         ["OK".to_string(),]
     );
 
     // TODO(dpark): Would there be a way to perform a closed-loop wait?
 
     // THEN
-    assert_eq!(p1_h.send_and_get("role", 1), vec!["follower"]);
-    assert_eq!(p2_h.send_and_get("role", 1), vec!["leader"]);
+    assert_eq!(p1_h.send_and_get_vec("role", 1), vec!["follower"]);
+    assert_eq!(p2_h.send_and_get_vec("role", 1), vec!["leader"]);
 
     // * Following is required to test replicaof successuflly update topology changes
     p1.terminate()?;
@@ -39,10 +39,10 @@ fn run_lazy_discovery_of_leader(with_append_only: bool) -> anyhow::Result<()> {
     let p1 = spawn_server_process(&new_env_with_same_topology, true)?;
 
     let mut p1_h = Client::new(p1.port);
-    assert_eq!(p1_h.send_and_get("get key", 1), vec!["(nil)"]);
-    assert_eq!(p1_h.send_and_get("get key2", 1), vec!["(nil)"]);
-    assert_eq!(p1_h.send_and_get("get other", 1), vec!["value"]);
-    assert_eq!(p1_h.send_and_get("get other2", 1), vec!["value2"]);
+    assert_eq!(p1_h.send_and_get_vec("get key", 1), vec!["(nil)"]);
+    assert_eq!(p1_h.send_and_get_vec("get key2", 1), vec!["(nil)"]);
+    assert_eq!(p1_h.send_and_get_vec("get other", 1), vec!["value"]);
+    assert_eq!(p1_h.send_and_get_vec("get other2", 1), vec!["value2"]);
 
     Ok(())
 }
@@ -62,15 +62,15 @@ fn run_invalid_replicaof(with_append_only: bool) -> anyhow::Result<()> {
 
     let mut p1_h = Client::new(p1.port);
 
-    p1_h.send_and_get("set key 1", 1);
+    p1_h.send_and_get("set key 1");
 
     // WHEN
     assert_eq!(
-        p1_h.send_and_get(format!("REPLICAOF 127.0.0.1 {}", &env1.port), 1),
-        ["(error) invalid operation: cannot replicate to self".to_string(),]
+        p1_h.send_and_get(format!("REPLICAOF 127.0.0.1 {}", &env1.port)),
+        "(error) invalid operation: cannot replicate to self"
     );
 
-    assert_eq!(p1_h.send_and_get("get key", 1), vec!["1"]);
+    assert_eq!(p1_h.send_and_get("get key"), "1");
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
+++ b/duva/tests/cluster_ops/test_reconnection_on_reboot.rs
@@ -10,9 +10,9 @@ fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()> {
 
     // Set some values
     let mut cli_to_p1 = Client::new(p1.port);
-    cli_to_p1.send_and_get("SET x value1".as_bytes(), 1);
-    cli_to_p1.send_and_get("SET y value2".as_bytes(), 1);
-    cli_to_p1.send_and_get("SET z value3".as_bytes(), 1);
+    cli_to_p1.send_and_get("SET x value1");
+    cli_to_p1.send_and_get("SET y value2");
+    cli_to_p1.send_and_get("SET z value3");
     drop(cli_to_p1);
 
     p2.kill()?;
@@ -24,18 +24,18 @@ fn run_reconnection_on_reboot(with_append_only: bool) -> anyhow::Result<()> {
     //THEN
 
     let mut cli_to_p2 = Client::new(p2.port);
-    let p2_role = cli_to_p2.send_and_get("ROLE".as_bytes(), 1);
+    let p2_role = cli_to_p2.send_and_get("ROLE");
 
     let mut cli_to_p1 = Client::new(p1.port);
-    let p1_role = cli_to_p1.send_and_get("ROLE".as_bytes(), 1);
+    let p1_role = cli_to_p1.send_and_get("ROLE");
 
-    assert_eq!(p2_role, vec!["follower".to_string()]);
-    assert_eq!(p1_role, vec!["leader".to_string()]);
+    assert_eq!(p2_role, "follower");
+    assert_eq!(p1_role, "leader");
 
     // Check that the values are still there
-    assert_eq!(cli_to_p2.send_and_get("GET x", 1), vec!["value1"]);
-    assert_eq!(cli_to_p2.send_and_get("GET y", 1), vec!["value2"]);
-    assert_eq!(cli_to_p2.send_and_get("GET z", 1), vec!["value3"]);
+    assert_eq!(cli_to_p2.send_and_get("GET x"), "value1");
+    assert_eq!(cli_to_p2.send_and_get("GET y"), "value2");
+    assert_eq!(cli_to_p2.send_and_get("GET z"), "value3");
 
     Ok(())
 }

--- a/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
+++ b/duva/tests/cluster_ops/test_removes_node_when_heartbeat_is_not_received_for_certain_time.rs
@@ -12,14 +12,14 @@ fn run_removes_node_when_heartbeat_is_not_received_for_certain_time(
     let [leader_p, mut repl_p] = form_cluster([&mut env, &mut repl_env], false);
 
     let mut h = Client::new(leader_p.port);
-    assert_eq!(h.send_and_get("cluster info", 1), vec!["cluster_known_nodes:1"]);
+    assert_eq!(h.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:1"]);
 
     // WHEN
     repl_p.kill()?;
     sleep(Duration::from_secs(2));
 
     //THEN
-    assert_eq!(h.send_and_get("cluster info", 1), vec!["cluster_known_nodes:0"]);
+    assert_eq!(h.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:0"]);
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_leader_election.rs
+++ b/duva/tests/replication_ops/test_leader_election.rs
@@ -20,7 +20,7 @@ fn run_leader_election(with_append_only: bool) -> anyhow::Result<()> {
     let mut flag = false;
     for f in [&follower_p1, &follower_p2] {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4);
+        let res = handler.send_and_get_vec("info replication", 4);
         if res.contains(&"role:leader".to_string()) {
             flag = true;
             break;
@@ -50,11 +50,11 @@ fn run_set_twice_after_election(with_append_only: bool) -> anyhow::Result<()> {
     let mut flag = false;
     for f in [&follower_p1, &follower_p2] {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4);
+        let res = handler.send_and_get_vec("info replication", 4);
         if res.contains(&"role:leader".to_string()) {
             // THEN - one of the replicas should become the leader
-            assert_eq!(handler.send_and_get("set 1 2", 1).first().unwrap(), "OK");
-            assert_eq!(handler.send_and_get("set 2 3", 1).first().unwrap(), "OK");
+            assert_eq!(handler.send_and_get("set 1 2"), "OK");
+            assert_eq!(handler.send_and_get("set 2 3"), "OK");
 
             flag = true;
             break;
@@ -83,7 +83,7 @@ fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
 
     for mut f in [follower_p1, follower_p2] {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4);
+        let res = handler.send_and_get_vec("info replication", 4);
         if !res.contains(&"role:leader".to_string()) {
             processes.push(f);
             continue;
@@ -105,7 +105,7 @@ fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
     let mut flag = false;
     for f in processes.iter() {
         let mut handler = Client::new(f.port);
-        let res = handler.send_and_get("info replication", 4);
+        let res = handler.send_and_get_vec("info replication", 4);
         if res.contains(&"role:leader".to_string()) {
             flag = true;
             break;

--- a/duva/tests/replication_ops/test_raft_happy_case.rs
+++ b/duva/tests/replication_ops/test_raft_happy_case.rs
@@ -15,13 +15,13 @@ fn run_set_operation_reaches_to_all_replicas(with_append_only: bool) -> anyhow::
 
     // WHEN -- set operation is made
     let mut client_handler = Client::new(leader_p.port);
-    client_handler.send_and_get("SET foo bar", 1);
+    client_handler.send_and_get("SET foo bar");
 
     //THEN
     sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX + 15));
 
     let mut client = Client::new(repl_p.port);
-    assert_eq!(client.send_and_get("GET foo", 1), vec!["bar"]);
+    assert_eq!(client.send_and_get("GET foo"), "bar");
 
     Ok(())
 }

--- a/duva/tests/replication_ops/test_sync.rs
+++ b/duva/tests/replication_ops/test_sync.rs
@@ -8,7 +8,7 @@ fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow::Resul
     let leader_p = spawn_server_process(&env, false)?;
     let mut h = Client::new(leader_p.port);
 
-    h.send_and_get("SET foo bar", 1);
+    h.send_and_get("SET foo bar");
 
     // WHEN run replica
     let repl_env = ServerEnv::default()
@@ -19,7 +19,7 @@ fn run_full_sync_on_newly_added_replica(with_append_only: bool) -> anyhow::Resul
 
     // THEN
     let mut client_to_repl = Client::new(replica_process.port);
-    assert_eq!(client_to_repl.send_and_get("KEYS *", 1), vec!["0) \"foo\""]);
+    assert_eq!(client_to_repl.send_and_get_vec("KEYS *", 1), vec!["0) \"foo\""]);
 
     Ok(())
 }


### PR DESCRIPTION
`set_and_get` has required cnt logic in case it requires more than a line.

For most of test case this is not needed. So one liner method that simply return `String` is added to simplify test. 