### PR TITLE
feat: background handshake spawn from inbound stream

### DIFF
--- a/duva/src/domains/caches/actor.rs
+++ b/duva/src/domains/caches/actor.rs
@@ -122,48 +122,6 @@ impl CacheActor {
         let _ = callback.send(Ok(curr + delta));
         val.value = (curr + delta).to_string();
     }
-
-    pub(crate) fn incr_by(
-        &mut self,
-        key: String,
-        increment: i64,
-        callback: oneshot::Sender<anyhow::Result<i64>>,
-    ) {
-        let val = self
-            .cache
-            .entry(key.clone())
-            .or_insert(CacheValue { value: "0".to_string(), expiry: None });
-
-        let Ok(curr) = val.value.parse::<i64>() else {
-            let _ =
-                callback.send(Err(anyhow::anyhow!("ERR value is not an integer or out of range")));
-            return;
-        };
-
-        let _ = callback.send(Ok(curr + increment));
-        val.value = (curr + increment).to_string();
-    }
-
-    pub(crate) fn decr_by(
-        &mut self,
-        key: String,
-        decrement: i64,
-        callback: oneshot::Sender<anyhow::Result<i64>>,
-    ) {
-        let val = self
-            .cache
-            .entry(key.clone())
-            .or_insert(CacheValue { value: "0".to_string(), expiry: None });
-
-        let Ok(curr) = val.value.parse::<i64>() else {
-            let _ =
-                callback.send(Err(anyhow::anyhow!("ERR value is not an integer or out of range")));
-            return;
-        };
-
-        let _ = callback.send(Ok(curr - decrement));
-        val.value = (curr - decrement).to_string();
-    }
 }
 
 #[derive(Default)]

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -550,10 +550,6 @@ impl ClusterActor {
         &mut self,
         logger: &mut ReplicatedLogs<impl TWriteAheadLog>,
     ) {
-        let ElectionState::Follower { voted_for: None } = &self.replication.election_state else {
-            return;
-        };
-
         self.become_candidate();
         let request_vote =
             RequestVote::new(&self.replication, logger.last_log_index, logger.last_log_index);

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -154,6 +154,7 @@ impl ClusterActor {
                     .collect(),
             )
             .ok();
+        let _ = self.snapshot_topology().await;
     }
     pub(crate) async fn remove_peer(&mut self, peer_addr: &PeerIdentifier) -> Option<()> {
         if let Some(peer) = self.members.remove(peer_addr) {
@@ -708,7 +709,6 @@ impl ClusterActor {
         self.step_down().await;
 
         let _ = self.connect_to_server(peer_addr, Some(callback)).await;
-        let _ = self.snapshot_topology().await;
     }
 
     /// Join existing cluster or node as partition leader
@@ -725,7 +725,6 @@ impl ClusterActor {
         // TODO set up number of partitions and its number of keys to be send from A to B
         // Should it be done in handshake? No because perhaps WHEN TO MIGRATE will be revisited
         let _ = self.connect_to_server(peer_addr, Some(callback)).await;
-        let _ = self.snapshot_topology().await;
     }
 
     pub(crate) async fn join_peer_network_if_absent(&mut self, cluster_nodes: Vec<PeerState>) {

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -565,7 +565,10 @@ impl ClusterActor {
 
     pub(crate) async fn vote_election(&mut self, request_vote: RequestVote, current_log_idx: u64) {
         let grant_vote = current_log_idx <= request_vote.last_log_index
-            && self.replication.may_become_follower(&request_vote.candidate_id, request_vote.term);
+            && self.replication.become_follower_if_term_higher_and_votable(
+                &request_vote.candidate_id,
+                request_vote.term,
+            );
 
         info!(
             "Voting for {} with term {} and granted: {}",

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -35,6 +35,7 @@ use tokio::net::TcpStream;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 #[derive(Debug)]
 pub struct ClusterActor {
@@ -157,6 +158,7 @@ impl ClusterActor {
         let _ = self.snapshot_topology().await;
     }
     pub(crate) async fn remove_peer(&mut self, peer_addr: &PeerIdentifier) -> Option<()> {
+        warn!("{} is being removed!", peer_addr);
         if let Some(peer) = self.members.remove(peer_addr) {
             // stop the runnin process and take the connection in case topology changes are made
             let _read_connected = peer.kill().await;

--- a/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
+++ b/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
@@ -21,7 +21,7 @@ pub(crate) enum ClusterCommand {
         connect_to: PeerIdentifier,
         callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
     },
-    AcceptPeer {
+    AcceptInboundPeer {
         stream: TcpStream,
     },
 

--- a/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
+++ b/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
@@ -8,7 +8,7 @@ use crate::{
             session::SessionRequest,
         },
         operation_logs::WriteRequest,
-        peers::peer::PeerState,
+        peers::peer::{Peer, PeerState},
     },
     prelude::PeerIdentifier,
 };
@@ -50,6 +50,7 @@ pub(crate) enum ClusterCommand {
         hwm: u64,
     },
     ClusterMeet(PeerIdentifier, tokio::sync::oneshot::Sender<anyhow::Result<()>>),
+    AddPeer(Peer),
 }
 
 #[derive(Debug)]

--- a/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
+++ b/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
@@ -51,6 +51,7 @@ pub(crate) enum ClusterCommand {
     },
     ClusterMeet(PeerIdentifier, tokio::sync::oneshot::Sender<anyhow::Result<()>>),
     AddPeer(Peer),
+    FollowerSetReplId(ReplicationId),
 }
 
 #[derive(Debug)]

--- a/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
+++ b/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
@@ -19,7 +19,7 @@ use super::{ConsensusClientResponse, ReplicationResponse, RequestVote, RequestVo
 pub(crate) enum ClusterCommand {
     DiscoverCluster {
         connect_to: PeerIdentifier,
-        callback: tokio::sync::oneshot::Sender<()>,
+        callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
     },
     AcceptPeer {
         stream: TcpStream,
@@ -50,7 +50,7 @@ pub(crate) enum ClusterCommand {
         hwm: u64,
     },
     ClusterMeet(PeerIdentifier, tokio::sync::oneshot::Sender<anyhow::Result<()>>),
-    AddPeer(Peer),
+    AddPeer(Peer, Option<tokio::sync::oneshot::Sender<anyhow::Result<()>>>),
     FollowerSetReplId(ReplicationId),
 }
 

--- a/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
+++ b/duva/src/domains/cluster_actors/commands/cluster_actor_command.rs
@@ -17,7 +17,7 @@ use super::{ConsensusClientResponse, ReplicationResponse, RequestVote, RequestVo
 
 #[derive(Debug)]
 pub(crate) enum ClusterCommand {
-    DiscoverCluster {
+    ConnectToServer {
         connect_to: PeerIdentifier,
         callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
     },

--- a/duva/src/domains/cluster_actors/consensus/election.rs
+++ b/duva/src/domains/cluster_actors/consensus/election.rs
@@ -1,3 +1,5 @@
+use tracing::warn;
+
 use crate::domains::{
     cluster_actors::replication::ReplicationRole, peers::identifier::PeerIdentifier,
 };
@@ -20,13 +22,14 @@ impl ElectionState {
         *self = ElectionState::Leader;
     }
     pub(crate) fn become_candidate(&mut self, replica_count: u8) {
-        *self = ElectionState::Candidate { voting: Some(ElectionVoting { cnt: 0, replica_count }) };
+        *self = ElectionState::Candidate { voting: Some(ElectionVoting::new(replica_count)) };
     }
 
-    pub(crate) fn is_votable(&self, candidiate_id: &PeerIdentifier) -> bool {
+    pub(crate) fn is_votable(&self, candidate_id: &PeerIdentifier) -> bool {
         match self {
-            ElectionState::Follower { voted_for } => {
-                voted_for.is_none() || voted_for.as_ref() == Some(candidiate_id)
+            ElectionState::Follower { voted_for } => match voted_for {
+                None => true,
+                Some(id) => id == candidate_id,
             },
             _ => false,
         }
@@ -51,6 +54,10 @@ pub(crate) struct ElectionVoting {
 }
 
 impl ElectionVoting {
+    pub(crate) fn new(replica_count: u8) -> Self {
+        // ! one for selv vote
+        Self { cnt: 1, replica_count }
+    }
     fn get_required_votes(&self) -> u8 {
         (self.replica_count + 1).div_ceil(2)
     }
@@ -58,9 +65,14 @@ impl ElectionVoting {
         self.cnt += 1;
 
         let required_count = self.get_required_votes();
+
         if self.cnt >= required_count {
             return None;
         }
+        warn!(
+            "Voting not finished yet, curent count{}, required count{}",
+            self.cnt, required_count
+        );
         Some(self)
     }
 }

--- a/duva/src/domains/cluster_actors/listener.rs
+++ b/duva/src/domains/cluster_actors/listener.rs
@@ -2,6 +2,7 @@ use crate::{
     domains::{
         cluster_actors::commands::{ClusterCommand, PeerListenerCommand},
         peers::{
+            connected_peer_info::ConnectedPeerInfo,
             connected_types::ReadConnected,
             peer::{ListeningActorKillTrigger, Peer},
         },
@@ -9,14 +10,10 @@ use crate::{
     prelude::PeerIdentifier,
     services::interface::TRead,
 };
-use tokio::{
-    net::tcp::{OwnedReadHalf, OwnedWriteHalf},
-    select,
-    sync::mpsc::Sender,
-};
+use tokio::{net::tcp::OwnedReadHalf, select, sync::mpsc::Sender};
 use tracing::debug;
 
-use super::peer_connections::inbound::stream::InboundStream;
+use super::peer_connections::{inbound::stream::InboundStream, outbound::stream::OutboundStream};
 
 #[cfg(test)]
 static ATOMIC: std::sync::atomic::AtomicI16 = std::sync::atomic::AtomicI16::new(0);
@@ -64,7 +61,6 @@ impl PeerListener {
             .listen(kill_switch),
         );
         let kill_switch = ListeningActorKillTrigger::new(kill_trigger, handle);
-
         Ok(Peer::new(inbound_stream.w, peer_state, kill_switch))
     }
 

--- a/duva/src/domains/cluster_actors/listener.rs
+++ b/duva/src/domains/cluster_actors/listener.rs
@@ -94,11 +94,11 @@ impl PeerListener {
                 }
             }
         }
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self
-            .cluster_handler
-            .send(ClusterCommand::ForgetPeer(self.listening_to.clone(), tx))
-            .await;
-        rx.await.ok();
+        // let (tx, rx) = tokio::sync::oneshot::channel();
+        // let _ = self
+        //     .cluster_handler
+        //     .send(ClusterCommand::ForgetPeer(self.listening_to.clone(), tx))
+        //     .await;
+        // rx.await.ok();
     }
 }

--- a/duva/src/domains/cluster_actors/listener.rs
+++ b/duva/src/domains/cluster_actors/listener.rs
@@ -94,11 +94,5 @@ impl PeerListener {
                 }
             }
         }
-        // let (tx, rx) = tokio::sync::oneshot::channel();
-        // let _ = self
-        //     .cluster_handler
-        //     .send(ClusterCommand::ForgetPeer(self.listening_to.clone(), tx))
-        //     .await;
-        // rx.await.ok();
     }
 }

--- a/duva/src/domains/cluster_actors/listener.rs
+++ b/duva/src/domains/cluster_actors/listener.rs
@@ -1,11 +1,7 @@
-use super::peer_connections::inbound::stream::InboundStream;
 use crate::{
     domains::{
         cluster_actors::commands::{ClusterCommand, PeerListenerCommand},
-        peers::{
-            connected_types::ReadConnected,
-            peer::{ListeningActorKillTrigger, Peer},
-        },
+        peers::{connected_types::ReadConnected, peer::ListeningActorKillTrigger},
     },
     prelude::PeerIdentifier,
     services::interface::TRead,

--- a/duva/src/domains/cluster_actors/peer_connections/inbound/stream.rs
+++ b/duva/src/domains/cluster_actors/peer_connections/inbound/stream.rs
@@ -7,7 +7,7 @@ use crate::domains::cluster_actors::replication::ReplicationId;
 use crate::domains::cluster_actors::replication::ReplicationState;
 use crate::domains::peers::connected_peer_info::ConnectedPeerInfo;
 use crate::domains::peers::identifier::PeerIdentifier;
-use crate::domains::peers::peer::Peer;
+
 use crate::domains::peers::peer::PeerState;
 use crate::domains::query_parsers::QueryIO;
 use crate::services::interface::TRead;
@@ -153,7 +153,6 @@ impl InboundStream {
         self.recv_handshake().await?;
         self.disseminate_peers(members).await?;
         let peer = PeerListener::spawn_from_inbound_stream(self, cluster_handler.clone()).await?;
-
         let _ = cluster_handler.send(ClusterCommand::AddPeer(peer)).await;
         Ok(())
     }

--- a/duva/src/domains/cluster_actors/peer_connections/inbound/stream.rs
+++ b/duva/src/domains/cluster_actors/peer_connections/inbound/stream.rs
@@ -150,7 +150,7 @@ impl InboundStream {
         self.recv_handshake().await?;
         self.disseminate_peers(members).await?;
         let peer = PeerListener::spawn_from_inbound_stream(self, cluster_handler.clone()).await?;
-        let _ = cluster_handler.send(ClusterCommand::AddPeer(peer)).await;
+        let _ = cluster_handler.send(ClusterCommand::AddPeer(peer, None)).await;
         Ok(())
     }
 }

--- a/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
+++ b/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
@@ -102,10 +102,6 @@ impl OutboundStream {
         Ok(())
     }
 
-    fn take_connection_info(&mut self) -> anyhow::Result<ConnectedPeerInfo> {
-        Ok(self.connected_node_info.take().context("Connected node info not found")?)
-    }
-
     pub(crate) async fn add_peer(
         mut self,
         self_port: u16,
@@ -113,7 +109,8 @@ impl OutboundStream {
         optional_callback: Option<tokio::sync::oneshot::Sender<anyhow::Result<()>>>,
     ) -> anyhow::Result<()> {
         self.make_handshake(self_port).await?;
-        let connection_info = self.take_connection_info()?;
+        let connection_info =
+            self.connected_node_info.take().context("Connected node info not found")?;
         if self.my_repl_info.replid == ReplicationId::Undecided {
             let _ = cluster_handler
                 .send(ClusterCommand::FollowerSetReplId(connection_info.replid.clone()))

--- a/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
+++ b/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
@@ -110,6 +110,7 @@ impl OutboundStream {
         mut self,
         self_port: u16,
         cluster_handler: tokio::sync::mpsc::Sender<ClusterCommand>,
+        optional_callback: Option<tokio::sync::oneshot::Sender<anyhow::Result<()>>>,
     ) -> anyhow::Result<()> {
         self.make_handshake(self_port).await?;
         let connection_info = self.take_connection_info()?;
@@ -132,7 +133,7 @@ impl OutboundStream {
 
         let peer =
             Peer::new(self.w, peer_state, ListeningActorKillTrigger::new(kill_trigger, handle));
-        let _ = cluster_handler.send(ClusterCommand::AddPeer(peer)).await;
+        let _ = cluster_handler.send(ClusterCommand::AddPeer(peer, optional_callback)).await;
         Ok(())
     }
 }

--- a/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
+++ b/duva/src/domains/cluster_actors/peer_connections/outbound/stream.rs
@@ -111,13 +111,14 @@ impl OutboundStream {
         self.make_handshake(self_port).await?;
         let connection_info =
             self.connected_node_info.take().context("Connected node info not found")?;
+
         if self.my_repl_info.replid == ReplicationId::Undecided {
             let _ = cluster_handler
                 .send(ClusterCommand::FollowerSetReplId(connection_info.replid.clone()))
                 .await;
         }
-
         let peer_state = connection_info.decide_peer_kind(&self.my_repl_info.replid);
+
         let kill_switch = PeerListener::spawn(self.r, cluster_handler.clone(), self.connect_to);
         let peer = Peer::new(self.w, peer_state, kill_switch);
 

--- a/duva/src/domains/cluster_actors/replication.rs
+++ b/duva/src/domains/cluster_actors/replication.rs
@@ -1,5 +1,3 @@
-use tracing::info;
-
 use super::consensus::ElectionState;
 pub(crate) use super::heartbeats::heartbeat::BannedPeer;
 pub(crate) use super::heartbeats::heartbeat::HeartBeatMessage;

--- a/duva/src/domains/cluster_actors/replication.rs
+++ b/duva/src/domains/cluster_actors/replication.rs
@@ -113,11 +113,6 @@ impl ReplicationState {
         }
     }
 
-    pub(crate) fn become_candidate(&mut self, replica_count: u8) {
-        self.term += 1;
-
-        self.election_state.become_candidate(replica_count);
-    }
     pub(crate) fn may_become_follower(
         &mut self,
         candidate_id: &PeerIdentifier,

--- a/duva/src/domains/cluster_actors/replication.rs
+++ b/duva/src/domains/cluster_actors/replication.rs
@@ -1,3 +1,5 @@
+use tracing::info;
+
 use super::consensus::ElectionState;
 pub(crate) use super::heartbeats::heartbeat::BannedPeer;
 pub(crate) use super::heartbeats::heartbeat::HeartBeatMessage;
@@ -113,16 +115,28 @@ impl ReplicationState {
         }
     }
 
-    pub(crate) fn may_become_follower(
+    pub(crate) fn become_follower_if_term_higher_and_votable(
         &mut self,
         candidate_id: &PeerIdentifier,
         election_term: u64,
     ) -> bool {
-        if !(self.election_state.is_votable(candidate_id) && self.term < election_term) {
+        // If the candidate's term is less than mine → reject
+        if election_term < self.term {
             return false;
         }
+
+        // When a node sees a higher term, it must forget any vote it cast in a prior term, because:
+        if election_term > self.term {
+            self.term = election_term;
+            self.vote_for(None);
+        }
+
+        if !self.election_state.is_votable(candidate_id) {
+            return false;
+        }
+
         self.vote_for(Some(candidate_id.clone()));
-        self.term = election_term;
+
         true
     }
 

--- a/duva/src/domains/peers/connected_peer_info.rs
+++ b/duva/src/domains/peers/connected_peer_info.rs
@@ -14,10 +14,6 @@ pub(crate) struct ConnectedPeerInfo {
 }
 
 impl ConnectedPeerInfo {
-    pub(crate) fn list_peer_binding_addrs(&mut self) -> Vec<PeerIdentifier> {
-        std::mem::take(&mut self.peer_list).into_iter().map(Into::into).collect::<Vec<_>>()
-    }
-
     pub(crate) fn decide_peer_kind(&self, my_repl_id: &ReplicationId) -> PeerState {
         match (my_repl_id, &self.replid) {
             // Peer is undecided - assign as replica with our replication ID

--- a/duva/src/domains/peers/identifier.rs
+++ b/duva/src/domains/peers/identifier.rs
@@ -65,3 +65,19 @@ impl std::fmt::Display for PeerIdentifier {
         )
     }
 }
+
+#[test]
+fn test_peer_identifier() {
+    let peer = PeerIdentifier::new("127.0.0.1", 1234);
+    let peer2 = PeerIdentifier::new("127.0.0.3", 1234);
+
+    assert!(peer < peer2);
+}
+
+#[test]
+fn test_peer_identifier2() {
+    let peer = PeerIdentifier::new("127.0.0.1", 1234);
+    let peer2 = PeerIdentifier::new("127.0.0.1", 1235);
+
+    assert!(peer < peer2);
+}

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -87,13 +87,14 @@ impl StartUpFacade {
 
     async fn discover_cluster(&self, env: Environment) -> Result<(), anyhow::Error> {
         if let Some(seed) = env.seed_server {
-            return self.registry.cluster_communication_manager.discover_cluster(seed).await;
+            return self.registry.cluster_communication_manager.connect_to_server(seed).await;
         }
 
         for peer in env.pre_connected_peers {
-            if self.registry.cluster_communication_manager.discover_cluster(peer.addr).await.is_ok()
+            if let Err(err) =
+                self.registry.cluster_communication_manager.connect_to_server(peer.addr).await
             {
-                break;
+                error!("{err}");
             }
         }
 

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -116,7 +116,7 @@ impl StartUpFacade {
                     debug!("Accepted peer connection: {}", socket_addr);
                     if registry
                         .cluster_communication_manager
-                        .send(ClusterCommand::AcceptPeer { stream: peer_stream })
+                        .send(ClusterCommand::AcceptInboundPeer { stream: peer_stream })
                         .await
                         .is_err()
                     {

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -73,7 +73,7 @@ impl ClusterCommunicationManager {
     pub(crate) async fn cluster_meet(&self, peer_identifier: PeerIdentifier) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let _ = self.send(ClusterCommand::ClusterMeet(peer_identifier, tx)).await;
-        Ok(rx.await??)
+        rx.await?
     }
 
     pub(crate) async fn cluster_nodes(&self) -> anyhow::Result<Vec<PeerState>> {

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -26,7 +26,7 @@ impl ClusterCommunicationManager {
     pub(crate) async fn discover_cluster(&self, connect_to: PeerIdentifier) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.send(ClusterCommand::DiscoverCluster { connect_to, callback: tx }).await?;
-        rx.await?;
+        rx.await??;
         Ok(())
     }
 

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -23,9 +23,9 @@ impl ClusterCommunicationManager {
         Ok(peers)
     }
 
-    pub(crate) async fn discover_cluster(&self, connect_to: PeerIdentifier) -> anyhow::Result<()> {
+    pub(crate) async fn connect_to_server(&self, connect_to: PeerIdentifier) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClusterCommand::DiscoverCluster { connect_to, callback: tx }).await?;
+        self.send(ClusterCommand::ConnectToServer { connect_to, callback: tx }).await?;
         rx.await??;
         Ok(())
     }

--- a/duva/src/services/handlers/cluster.rs
+++ b/duva/src/services/handlers/cluster.rs
@@ -7,8 +7,7 @@ use crate::domains::operation_logs::interfaces::TWriteAheadLog;
 use crate::domains::operation_logs::logger::ReplicatedLogs;
 use crate::err;
 use tokio::sync::mpsc::Sender;
-
-use tracing::{error, info, trace};
+use tracing::{info, trace};
 
 impl ClusterActor {
     pub(crate) async fn handle(
@@ -22,15 +21,11 @@ impl ClusterActor {
         while let Some(command) = self.receiver.recv().await {
             trace!(?command, "Cluster command received");
             match command {
-                ClusterCommand::DiscoverCluster { connect_to, callback } => {
-                    if let Err(e) = self.connect_to_server(connect_to, Some(callback)).await {
-                        error!("{e}");
-                    };
+                ClusterCommand::ConnectToServer { connect_to, callback } => {
+                    self.connect_to_server(connect_to, Some(callback)).await;
                 },
                 ClusterCommand::AcceptPeer { stream } => {
-                    if let Err(e) = self.accept_inbound_stream(stream).await {
-                        error!("{e}");
-                    }
+                    self.accept_inbound_stream(stream).await;
                 },
                 ClusterCommand::GetPeers(callback) => {
                     let _ = callback.send(self.members.keys().cloned().collect::<Vec<_>>());

--- a/duva/src/services/handlers/cluster.rs
+++ b/duva/src/services/handlers/cluster.rs
@@ -7,7 +7,7 @@ use crate::domains::operation_logs::interfaces::TWriteAheadLog;
 use crate::domains::operation_logs::logger::ReplicatedLogs;
 use crate::err;
 use tokio::sync::mpsc::Sender;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 impl ClusterActor {
     pub(crate) async fn handle(

--- a/duva/src/services/handlers/cluster.rs
+++ b/duva/src/services/handlers/cluster.rs
@@ -24,7 +24,7 @@ impl ClusterActor {
                 ClusterCommand::ConnectToServer { connect_to, callback } => {
                     self.connect_to_server(connect_to, Some(callback)).await;
                 },
-                ClusterCommand::AcceptPeer { stream } => {
+                ClusterCommand::AcceptInboundPeer { stream } => {
                     self.accept_inbound_stream(stream).await;
                 },
                 ClusterCommand::GetPeers(callback) => {

--- a/duva/src/services/handlers/cluster.rs
+++ b/duva/src/services/handlers/cluster.rs
@@ -21,7 +21,7 @@ impl ClusterActor {
         while let Some(command) = self.receiver.recv().await {
             match command {
                 ClusterCommand::DiscoverCluster { connect_to, callback } => {
-                    if self.discover_cluster(connect_to).await.is_ok() {
+                    if self.connect_to_server(connect_to).await.is_ok() {
                         let _ = self.snapshot_topology().await;
                     };
                     let _ = callback.send(());
@@ -140,6 +140,9 @@ impl ClusterActor {
                     let _ = sender.send(self.node_change_broadcast.subscribe());
                 },
                 ClusterCommand::AddPeer(peer) => self.add_peer(peer).await,
+                ClusterCommand::FollowerSetReplId(replication_id) => {
+                    self.set_repl_id(replication_id)
+                },
             }
         }
         Ok(self)

--- a/duva/src/services/handlers/cluster.rs
+++ b/duva/src/services/handlers/cluster.rs
@@ -59,7 +59,6 @@ impl ClusterActor {
                     self.gossip(heartbeat.hop_count, &logger).await;
                     self.update_on_hertbeat_message(&heartbeat.from, heartbeat.hwm);
                 },
-
                 ClusterCommand::ForgetPeer(peer_addr, sender) => {
                     if let Ok(Some(())) = self.forget_peer(peer_addr).await {
                         let _ = sender.send(Some(()));
@@ -124,7 +123,6 @@ impl ClusterActor {
                     cache_manager.drop_cache().await;
                     self.replicaof(peer_addr, &mut logger, callback).await;
                 },
-
                 ClusterCommand::ClusterMeet(peer_addr, callback) => {
                     if !self.replication.is_leader_mode
                         || self.replication.self_identifier() == peer_addr
@@ -135,13 +133,13 @@ impl ClusterActor {
                     }
                     self.cluster_meet(peer_addr, callback).await;
                 },
-
                 ClusterCommand::GetRole(sender) => {
                     let _ = sender.send(self.replication.role.clone());
                 },
                 ClusterCommand::SubscribeToTopologyChange(sender) => {
                     let _ = sender.send(self.node_change_broadcast.subscribe());
                 },
+                ClusterCommand::AddPeer(peer) => self.add_peer(peer).await,
             }
         }
         Ok(self)

--- a/duva/tests/cluster_ops/test_cluster_meet.rs
+++ b/duva/tests/cluster_ops/test_cluster_meet.rs
@@ -22,6 +22,8 @@ fn run_cluster_meet(append_only: bool) -> anyhow::Result<()> {
     assert_eq!(client_handler.send_and_get(&cmd), "OK");
 
     // WHEN & THEN
+    // backoff time
+    std::thread::sleep(std::time::Duration::from_millis(3000));
     assert_eq!(client_handler.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:3"]);
     assert_eq!(client_handler.send_and_get("role"), "leader");
 

--- a/duva/tests/cluster_ops/test_cluster_meet.rs
+++ b/duva/tests/cluster_ops/test_cluster_meet.rs
@@ -22,15 +22,32 @@ fn run_cluster_meet(append_only: bool) -> anyhow::Result<()> {
     assert_eq!(client_handler.send_and_get(&cmd), "OK");
 
     // WHEN & THEN
-    // backoff time
-    std::thread::sleep(std::time::Duration::from_millis(3000));
-    assert_eq!(client_handler.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:3"]);
-    assert_eq!(client_handler.send_and_get("role"), "leader");
+    let mut success_cnt = 0;
+    // backoff time try for 3 seconds
+    let until = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while until > std::time::Instant::now() {
+        let res = client_handler.send_and_get_vec("cluster info", 1);
+        if res.contains(&"cluster_known_nodes:3".to_string()) {
+            assert_eq!(client_handler.send_and_get("role"), "leader");
+            success_cnt += 1;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 
-    // WHEN query is given to joining replica
     let mut replica_handler = Client::new(env4.port);
-    assert_eq!(replica_handler.send_and_get_vec("cluster info", 1), vec!["cluster_known_nodes:3"]);
-    assert_eq!(replica_handler.send_and_get("role"), "follower");
+    // WHEN query is given to joining replica
+    while until > std::time::Instant::now() {
+        let res = replica_handler.send_and_get_vec("cluster info", 1);
+        if res.contains(&"cluster_known_nodes:3".to_string()) {
+            assert_eq!(replica_handler.send_and_get("role"), "follower");
+            success_cnt += 1;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    assert_eq!(success_cnt, 2, "Cluster meet failed to add new nodes");
     Ok(())
 }
 

--- a/duva/tests/cluster_ops/test_heartbeat.rs
+++ b/duva/tests/cluster_ops/test_heartbeat.rs
@@ -2,29 +2,19 @@
 //! Any interconnected system should have a heartbeat mechanism to ensure that the connection is still alive
 //! In this case, the server will send PING message to the follower and the follower will respond with PONG message
 
-use crate::common::{
-    ServerEnv, check_internodes_communication, form_cluster, spawn_server_process,
-};
+use crate::common::{ServerEnv, check_internodes_communication, form_cluster};
 
 fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow::Result<()> {
     const DEFAULT_HOP_COUNT: usize = 0;
-    const TIMEOUT_IN_MILLIS: u128 = 2000;
+    const TIMEOUT_IN_MILLIS: u128 = 3000;
     // GIVEN
     let mut env = ServerEnv::default().with_append_only(with_append_only);
     let mut repl_env = ServerEnv::default().with_append_only(with_append_only);
     let mut repl_env2 = ServerEnv::default().with_append_only(with_append_only);
+    let mut repl_env3 = ServerEnv::default().with_append_only(with_append_only);
 
-    // Form cluster with leader and replica
-    let cluster = form_cluster([&mut env, &mut repl_env, &mut repl_env2], true);
-
-    // WHEN run third follower
-    let repl_env3 = ServerEnv::default()
-        .with_bind_addr(cluster[0].bind_addr())
-        .with_append_only(with_append_only);
-    let follower_p3 = spawn_server_process(&repl_env3, true)?;
-
-    let mut cluster: Vec<_> = cluster.into();
-    cluster.push(follower_p3);
+    // Form when
+    let mut cluster = form_cluster([&mut env, &mut repl_env, &mut repl_env2, &mut repl_env3], true);
 
     // THEN - some of the followers will have hop_count 1 and some will have hop_count 0
     let res = check_internodes_communication(
@@ -37,42 +27,10 @@ fn run_heartbeat_hop_count_decreases_over_time(with_append_only: bool) -> anyhow
     Ok(())
 }
 
-fn run_heartbeat_hop_count_starts_with_0(with_append_only: bool) -> anyhow::Result<()> {
-    const DEFAULT_HOP_COUNT: usize = 0;
-    const TIMEOUT_IN_MILLIS: u128 = 2000;
-
-    // GIVEN
-    let mut env = ServerEnv::default().with_append_only(with_append_only);
-    let mut repl_env = ServerEnv::default().with_append_only(with_append_only);
-    let mut repl_env2 = ServerEnv::default().with_append_only(with_append_only);
-
-    // WHEN
-    // Form cluster with leader and replica
-    let mut cluster = form_cluster([&mut env, &mut repl_env, &mut repl_env2], true);
-
-    // THEN
-    // ! no node should have hop_count 1
-    let res = check_internodes_communication(
-        &mut cluster.iter_mut().collect::<Vec<_>>().as_mut(),
-        DEFAULT_HOP_COUNT + 1,
-        TIMEOUT_IN_MILLIS,
-    );
-    assert!(res.is_err());
-
-    Ok(())
-}
-
 #[test]
 fn test_heartbeat_hop_count_decreases_over_time() -> anyhow::Result<()> {
     run_heartbeat_hop_count_decreases_over_time(false)?;
     run_heartbeat_hop_count_decreases_over_time(true)?;
 
-    Ok(())
-}
-
-#[test]
-fn test_heartbeat_hop_count_starts_with_0() -> anyhow::Result<()> {
-    run_heartbeat_hop_count_starts_with_0(false)?;
-    run_heartbeat_hop_count_starts_with_0(true)?;
     Ok(())
 }

--- a/duva/tests/common.rs
+++ b/duva/tests/common.rs
@@ -426,7 +426,7 @@ pub fn form_cluster<const T: usize>(
         unsafe { processes.iter_mut().map(|p| &mut *(p.as_mut_ptr())).collect::<Vec<_>>() };
 
     if stdout_enabled {
-        check_internodes_communication(&mut process_refs, 0, 10000).unwrap();
+        check_internodes_communication(&mut process_refs, 0, 1000).unwrap();
     }
 
     // Convert the array of MaybeUninit to an initialized array safely

--- a/duva/tests/common.rs
+++ b/duva/tests/common.rs
@@ -426,7 +426,7 @@ pub fn form_cluster<const T: usize>(
         unsafe { processes.iter_mut().map(|p| &mut *(p.as_mut_ptr())).collect::<Vec<_>>() };
 
     if stdout_enabled {
-        check_internodes_communication(&mut process_refs, 0, 1000).unwrap();
+        check_internodes_communication(&mut process_refs, 0, 10000).unwrap();
     }
 
     // Convert the array of MaybeUninit to an initialized array safely

--- a/duva/tests/replication_ops/test_leader_election.rs
+++ b/duva/tests/replication_ops/test_leader_election.rs
@@ -77,6 +77,9 @@ fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
 
     // !first leader is killed -> election happens
     leader_p.kill()?;
+    let mut tmp_h = Client::new(follower_p1.port);
+    tmp_h.send_and_get(format!("cluster forget 127.0.0.1:{}", leader_p.port));
+
     sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
 
     let mut processes = vec![];
@@ -93,6 +96,9 @@ fn run_leader_election_twice(with_append_only: bool) -> anyhow::Result<()> {
             ServerEnv::default().with_bind_addr(f.bind_addr()).with_append_only(with_append_only);
         let new_process = spawn_server_process(&follower_env3, false)?;
         sleep(Duration::from_millis(LEADER_HEARTBEAT_INTERVAL_MAX));
+
+        let mut tmp_h = Client::new(follower_env3.port);
+        tmp_h.send_and_get(format!("cluster forget 127.0.0.1:{}", f.port));
 
         // WHEN
         // ! second leader is killed -> election happens


### PR DESCRIPTION
As cluster actor is single synchronization point, hangs on cluster actor may incur logical deadlock. 
This PR is aimed at improving that process .


#### Operational deadlock 
When synchrornization happens in cluster actor, concurrent handshakes requests can block each other, leading to operational deadlock.



#### Connection collision
classic issue in distributed systems when implementing a gossip protocol: concurrent connection attempts between two nodes (B and C) leading to duplicate connections, where only one should persist due to the constraint of maintaining a single stream.
