### PR TITLE
feat: optional rebalancing trigger

### DIFF
--- a/duva-client/src/cli/editor/hints.rs
+++ b/duva-client/src/cli/editor/hints.rs
@@ -129,7 +129,8 @@ pub(crate) fn default_hints() -> HashSet<CommandHint> {
     set.insert(CommandHint::new("cluster info", "cluster "));
     set.insert(CommandHint::new("cluster nodes", "cluster "));
     set.insert(CommandHint::new("cluster forget node", "cluster "));
-    set.insert(CommandHint::new("cluster meet node", "cluster "));
+
+    set.insert(CommandHint::new("cluster meet node [lazy|eager]", "cluster "));
     set.insert(CommandHint::new("ping", ""));
     set.insert(CommandHint::new("keys pattern", "keys "));
     set.insert(CommandHint::new("info [section]", ""));
@@ -170,7 +171,7 @@ pub(crate) fn dynamic_hints() -> HashMap<&'static str, Vec<DynamicHint>> {
     map.insert("decrby", vec![hint!("key decrement", 0), hint!("decrement", 1)]);
 
     map.insert("cluster forget", vec![hint!("node", 0)]);
-    map.insert("cluster meet", vec![hint!("node", 0)]);
+    map.insert("cluster meet", vec![hint!("node [lazy|eager]", 0), hint!("[lazy|eager]", 1)]);
     map.insert("keys", vec![hint!("pattern", 0)]);
     map.insert("get", vec![hint!("key", 0)]);
     map.insert("exists", vec![hint!("key [key ...]", 0, repeat), hint!("[key ...]", 1, repeat)]);

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -720,7 +720,9 @@ impl ClusterActor {
         peer_addr: PeerIdentifier,
         callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
     ) {
-        self.pending_requests = Some(VecDeque::new());
+        // TODO following should be optional - Eagerly or Lazily
+
+        // self.pending_requests = Some(VecDeque::new());
 
         // TODO set up number of partitions and its number of keys to be send from A to B
         // Should it be done in handshake? No because perhaps WHEN TO MIGRATE will be revisited

--- a/duva/src/domains/cluster_actors/commands/command.rs
+++ b/duva/src/domains/cluster_actors/commands/command.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use tokio::net::TcpStream;
 
 use crate::{
@@ -49,7 +51,7 @@ pub(crate) enum ClusterCommand {
         replid: ReplicationId,
         hwm: u64,
     },
-    ClusterMeet(PeerIdentifier, tokio::sync::oneshot::Sender<anyhow::Result<()>>),
+    ClusterMeet(PeerIdentifier, LazyOption, tokio::sync::oneshot::Sender<anyhow::Result<()>>),
     AddPeer(Peer, Option<tokio::sync::oneshot::Sender<anyhow::Result<()>>>),
     FollowerSetReplId(ReplicationId),
 }
@@ -73,5 +75,23 @@ impl ConsensusRequest {
 impl From<ConsensusRequest> for ClusterCommand {
     fn from(request: ConsensusRequest) -> Self {
         Self::LeaderReqConsensus(request)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum LazyOption {
+    Lazy,
+    Eager,
+}
+
+impl FromStr for LazyOption {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "lazy" => Ok(LazyOption::Lazy),
+            "eager" => Ok(LazyOption::Eager),
+            _ => Err(anyhow::anyhow!("Invalid value for LazyOption")),
+        }
     }
 }

--- a/duva/src/domains/cluster_actors/commands/command.rs
+++ b/duva/src/domains/cluster_actors/commands/command.rs
@@ -78,7 +78,7 @@ impl From<ConsensusRequest> for ClusterCommand {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LazyOption {
     Lazy,
     Eager,

--- a/duva/src/domains/cluster_actors/commands/mod.rs
+++ b/duva/src/domains/cluster_actors/commands/mod.rs
@@ -1,6 +1,6 @@
-mod cluster_actor_command;
+mod command;
 mod election;
 mod write_con;
-pub(crate) use cluster_actor_command::*;
+pub(crate) use command::*;
 pub(crate) use election::*;
 pub(crate) use write_con::*;

--- a/duva/src/domains/cluster_actors/service.rs
+++ b/duva/src/domains/cluster_actors/service.rs
@@ -127,7 +127,7 @@ impl ClusterActor {
                             .send(err!("wrong address or invalid state for cluster meet command"));
                         continue;
                     }
-                    self.cluster_meet(peer_addr, callback).await;
+                    self.cluster_meet(peer_addr, lazy_option, callback).await;
                 },
                 ClusterCommand::GetRole(sender) => {
                     let _ = sender.send(self.replication.role.clone());

--- a/duva/src/domains/cluster_actors/service.rs
+++ b/duva/src/domains/cluster_actors/service.rs
@@ -119,7 +119,7 @@ impl ClusterActor {
                     cache_manager.drop_cache().await;
                     self.replicaof(peer_addr, &mut logger, callback).await;
                 },
-                ClusterCommand::ClusterMeet(peer_addr, callback) => {
+                ClusterCommand::ClusterMeet(peer_addr, lazy_option, callback) => {
                     if !self.replication.is_leader_mode
                         || self.replication.self_identifier() == peer_addr
                     {

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -110,9 +110,11 @@ impl ClientController {
                     Err(e) => QueryIO::Err(e.to_string()),
                 }
             },
-            ClientAction::ClusterMeet(peer_identifier) => {
-                self.cluster_communication_manager.cluster_meet(peer_identifier).await?.into()
-            },
+            ClientAction::ClusterMeet(peer_identifier, option) => self
+                .cluster_communication_manager
+                .cluster_meet(peer_identifier, option)
+                .await?
+                .into(),
             ClientAction::ReplicaOf(peer_identifier) => {
                 self.cluster_communication_manager.replicaof(peer_identifier.clone()).await?;
                 QueryIO::SimpleString("OK".into())

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     domains::{
         cluster_actors::{
-            commands::ClusterCommand,
+            commands::{ClusterCommand, LazyOption},
             replication::{ReplicationRole, ReplicationState},
         },
         peers::{identifier::PeerIdentifier, peer::PeerState},
@@ -70,9 +70,13 @@ impl ClusterCommunicationManager {
         rx.await?
     }
 
-    pub(crate) async fn cluster_meet(&self, peer_identifier: PeerIdentifier) -> anyhow::Result<()> {
+    pub(crate) async fn cluster_meet(
+        &self,
+        peer_identifier: PeerIdentifier,
+        lazy_option: LazyOption,
+    ) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self.send(ClusterCommand::ClusterMeet(peer_identifier, tx)).await;
+        let _ = self.send(ClusterCommand::ClusterMeet(peer_identifier, lazy_option, tx)).await;
         rx.await?
     }
 


### PR DESCRIPTION
`Cluster Meet` operation may/may not trigger rebalancing right on arrival of request. 
`LazyOption` will decide how promptly it will react. 

If `Eager` is given, it will ask connected node to start rebalancing, blocking subsequent user write opeartions.
Otherwise, it will wait until client triggers rebalancing. 

 #530 