### PR TITLE
refactor: encapsulate logger

### DIFF
--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -38,7 +38,7 @@ use tracing::info;
 use tracing::warn;
 
 #[derive(Debug)]
-pub struct ClusterActor<T: TWriteAheadLog> {
+pub struct ClusterActor<T> {
     pub(crate) members: BTreeMap<PeerIdentifier, Peer>,
     pub(crate) replication: ReplicationState,
     pub(crate) node_timeout: u128,

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -702,10 +702,9 @@ impl ClusterActor {
     pub(crate) async fn replicaof(
         &mut self,
         peer_addr: PeerIdentifier,
-        logger: &mut ReplicatedLogs<impl TWriteAheadLog>,
+
         callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
     ) {
-        logger.reset().await;
         self.replication.hwm.store(0, Ordering::Release);
         self.set_repl_id(ReplicationId::Undecided);
         self.step_down().await;

--- a/duva/src/domains/cluster_actors/service.rs
+++ b/duva/src/domains/cluster_actors/service.rs
@@ -86,8 +86,10 @@ impl ClusterActor {
                                     .send(err!("invalid operation: cannot replicate to self"));
                                 continue;
                             }
+
                             cache_manager.drop_cache().await;
-                            self.replicaof(peer_addr, &mut logger, callback).await;
+                            logger.reset().await;
+                            self.replicaof(peer_addr, callback).await;
                         },
                         | ClusterMeet(peer_addr, lazy_option, callback) => {
                             if !self.replication.is_leader_mode

--- a/duva/src/domains/cluster_actors/session.rs
+++ b/duva/src/domains/cluster_actors/session.rs
@@ -4,9 +4,10 @@ use uuid::Uuid;
 
 use crate::make_smart_pointer;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct ClientSessions(HashMap<Uuid, Session>);
 
+#[derive(Default, Debug)]
 pub(crate) struct Session {
     last_accessed: DateTime<Utc>,
     processed_req_id: Option<u64>,

--- a/duva/src/domains/operation_logs/logger.rs
+++ b/duva/src/domains/operation_logs/logger.rs
@@ -1,6 +1,7 @@
 use super::{WriteOperation, WriteRequest, interfaces::TWriteAheadLog};
 use tracing::debug;
 
+#[derive(Debug)]
 pub(crate) struct ReplicatedLogs<T: TWriteAheadLog> {
     pub(crate) target: T,
     pub(crate) last_log_index: u64,

--- a/duva/src/domains/operation_logs/logger.rs
+++ b/duva/src/domains/operation_logs/logger.rs
@@ -2,17 +2,18 @@ use super::{WriteOperation, WriteRequest, interfaces::TWriteAheadLog};
 use tracing::debug;
 
 #[derive(Debug)]
-pub(crate) struct ReplicatedLogs<T: TWriteAheadLog> {
+pub(crate) struct ReplicatedLogs<T> {
     pub(crate) target: T,
     pub(crate) last_log_index: u64,
     pub(crate) last_log_term: u64,
 }
-
-impl<T: TWriteAheadLog> ReplicatedLogs<T> {
+impl<T> ReplicatedLogs<T> {
     pub fn new(target: T, last_log_index: u64, last_log_term: u64) -> Self {
         Self { target, last_log_index, last_log_term }
     }
+}
 
+impl<T: TWriteAheadLog> ReplicatedLogs<T> {
     pub(crate) async fn list_append_log_entries(
         &self,
         low_watermark: Option<u64>,

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -143,7 +143,6 @@ impl StartUpFacade {
         info!("listening peer connection on {}...", peer_bind_addr);
         loop {
             match peer_listener.accept().await {
-                // ? how do we know if incoming connection is from a peer or replica?
                 | Ok((peer_stream, socket_addr)) => {
                     debug!("Accepted peer connection: {}", socket_addr);
                     if cluster_communication_manager


### PR DESCRIPTION
quite a bit of lines depends on internally/externally logger. 

Having realized that ClusterActor is indeed synchronization point, it's natural to observe common usecase between cluster actor and  replicated logs. Therefore, this PR is aimed at having `ClusterActor` encapsulate `ReplicatedLogs`. 