### PR TITLE
feat: revisit keys for reusability

### DIFF
--- a/duva/src/domains/caches/actor.rs
+++ b/duva/src/domains/caches/actor.rs
@@ -34,19 +34,15 @@ impl CacheActor {
         self.cache.keys_with_expiry()
     }
 
-    pub(crate) fn keys(&self, pattern: Option<String>, callback: oneshot::Sender<QueryIO>) {
+    pub(crate) fn keys(&self, pattern: Option<String>, callback: oneshot::Sender<Vec<String>>) {
         let keys = self
             .cache
             .keys()
             .filter_map(move |k| {
-                if pattern.as_ref().is_none_or(|p| k.contains(p)) {
-                    Some(QueryIO::BulkString(k.clone()))
-                } else {
-                    None
-                }
+                if pattern.as_ref().is_none_or(|p| k.contains(p)) { Some(k.clone()) } else { None }
             })
             .collect();
-        let _ = callback.send(QueryIO::Array(keys));
+        let _ = callback.send(keys);
     }
     pub(crate) fn delete(&mut self, key: String, callback: oneshot::Sender<bool>) {
         if let Some(_value) = self.cache.remove(&key) {

--- a/duva/src/domains/caches/actor.rs
+++ b/duva/src/domains/caches/actor.rs
@@ -1,6 +1,5 @@
 use super::cache_objects::{CacheEntry, CacheValue};
 use super::command::CacheCommand;
-use crate::domains::QueryIO;
 use crate::domains::caches::cache_db::CacheDb;
 use crate::domains::caches::read_queue::ReadQueue;
 use crate::make_smart_pointer;

--- a/duva/src/domains/caches/cache_db.rs
+++ b/duva/src/domains/caches/cache_db.rs
@@ -70,7 +70,7 @@ impl CacheDb {
         for key in keys_to_extract {
             if let Some(node_pin_box) = self.map.remove(&key) {
                 let node_ptr: NodeRawPtr = node_pin_box.get().into();
-                self.detach(node_ptr.into());
+                self.detach(node_ptr);
                 if node_ptr.as_ref().value.has_expiry() {
                     extracted_expiry_count += 1;
                 }
@@ -88,19 +88,19 @@ impl CacheDb {
         for node_pin_box in extracted_map.values_mut() {
             let node_ptr: NodeRawPtr = node_pin_box.get().into();
             if current_extracted_head.is_none() {
-                current_extracted_head = Some(node_ptr.into());
+                current_extracted_head = Some(node_ptr);
                 node_ptr.set_node_prev_link(None);
             } else {
                 // SAFETY: `prev_node_ptr` is valid and `node_ptr` is valid.
-                if let Some(p_ptr) = prev_node_ptr.clone() {
+                if let Some(p_ptr) = prev_node_ptr {
                     p_ptr.set_node_next_link(node_ptr.into());
                 }
                 node_ptr.set_node_prev_link(prev_node_ptr);
             }
             // SAFETY: `node_ptr` is valid.
             node_ptr.set_node_next_link(None);
-            current_extracted_tail = Some(node_ptr.into());
-            prev_node_ptr = Some(node_ptr.into());
+            current_extracted_tail = Some(node_ptr);
+            prev_node_ptr = Some(node_ptr);
         }
 
         CacheDb {

--- a/duva/src/domains/caches/cache_db/cache_node.rs
+++ b/duva/src/domains/caches/cache_db/cache_node.rs
@@ -41,16 +41,16 @@ impl NodeRawPtr {
 
     #[inline]
     pub(super) fn get_node_prev_link(self) -> Option<NodeRawPtr> {
-        unsafe { (*(self.0.as_ptr())).prev.clone() }
+        unsafe { (*(self.0.as_ptr())).prev }
     }
 
     #[inline]
     pub(super) fn get_node_next_link(self) -> Option<NodeRawPtr> {
-        unsafe { (*self.0.as_ptr()).next.clone() }
+        unsafe { (*self.0.as_ptr()).next }
     }
     #[inline]
     pub(super) fn as_ref(&self) -> &CacheNode {
-        unsafe { &*self.0.as_ref() }
+        unsafe { self.0.as_ref() }
     }
 
     // ! SAFETY: The caller guarantees `ptr` is valid and non-aliased for a mutable reference.
@@ -59,6 +59,6 @@ impl NodeRawPtr {
     // ! when encapsulating raw pointer usage.)
     #[inline]
     pub(super) fn value_mut(&mut self) -> &'static mut CacheValue {
-        unsafe { (&mut *self.0.as_ptr()).value.as_mut() }
+        unsafe { (*self.0.as_ptr()).value.as_mut() }
     }
 }

--- a/duva/src/domains/caches/cache_manager.rs
+++ b/duva/src/domains/caches/cache_manager.rs
@@ -1,4 +1,3 @@
-use crate::domains::QueryIO;
 use crate::domains::caches::actor::CacheActor;
 use crate::domains::caches::actor::CacheCommandSender;
 use crate::domains::caches::cache_objects::CacheEntry;
@@ -122,7 +121,7 @@ impl CacheManager {
         join_all(self.inboxes.iter().map(|shard| shard.send(CacheCommand::Ping))).await;
     }
 
-    pub(crate) async fn route_keys(&self, pattern: Option<String>) -> QueryIO {
+    pub(crate) async fn route_keys(&self, pattern: Option<String>) -> Vec<String> {
         let (senders, receivers) = self.oneshot_channels();
 
         // send keys to shards
@@ -135,7 +134,7 @@ impl CacheManager {
                 res.extend(keys)
             }
         }
-        QueryIO::Array(res.into_iter().map(|key| QueryIO::BulkString(key)).collect())
+        res
     }
     pub(crate) async fn apply_snapshot(self, key_values: Vec<CacheEntry>) -> Result<()> {
         // * Here, no need to think about index as it is to update state and no return is required
@@ -144,18 +143,9 @@ impl CacheManager {
         }))
         .await;
 
-        // TODO let's find the way to test without adding the following code - echo
-        if let QueryIO::Array(data) = self.route_keys(None).await {
-            let mut keys = vec![];
-            for key in data {
-                let QueryIO::BulkString(key) = key else {
-                    continue;
-                };
-                keys.push(key);
-            }
+        let keys = self.route_keys(None).await;
+        debug!("Full Sync Keys: {:?}", keys);
 
-            debug!("Full Sync Keys: {:?}", keys);
-        }
         Ok(())
     }
 

--- a/duva/src/domains/caches/command.rs
+++ b/duva/src/domains/caches/command.rs
@@ -1,12 +1,12 @@
 use super::cache_objects::{CacheEntry, CacheValue};
-use crate::domains::{QueryIO, saves::command::SaveCommand};
+use crate::domains::saves::command::SaveCommand;
 use tokio::sync::{mpsc, oneshot};
 
 pub(crate) enum CacheCommand {
     Set { cache_entry: CacheEntry },
     Save { outbox: mpsc::Sender<SaveCommand> },
     Get { key: String, callback: oneshot::Sender<Option<CacheValue>> },
-    Keys { pattern: Option<String>, callback: oneshot::Sender<QueryIO> },
+    Keys { pattern: Option<String>, callback: oneshot::Sender<Vec<String>> },
     Delete { key: String, callback: oneshot::Sender<bool> },
     IndexGet { key: String, read_idx: u64, callback: oneshot::Sender<Option<CacheValue>> },
     Ping,

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -934,6 +934,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         }
 
         // TODO replcae vec with actual keys
+        let keys = cache_manager.route_keys(None).await;
         let _migration_tasks = self.hash_ring.create_migration_tasks(&ring, vec![]).await;
     }
 }

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -929,12 +929,11 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
             warn!("Received outdated hashring, ignoring");
             return;
         }
-        if let None = self.pending_requests {
+        if self.pending_requests.is_none() {
             self.pending_requests = Some(VecDeque::new());
         }
 
-        // TODO replcae vec with actual keys
         let keys = cache_manager.route_keys(None).await;
-        let _migration_tasks = self.hash_ring.create_migration_tasks(&ring, vec![]).await;
+        let _migration_tasks = self.hash_ring.create_migration_tasks(&ring, keys).await;
     }
 }

--- a/duva/src/domains/cluster_actors/hash_ring/migration_task.rs
+++ b/duva/src/domains/cluster_actors/hash_ring/migration_task.rs
@@ -1,0 +1,9 @@
+use crate::ReplicationId;
+
+#[derive(Debug, Clone)]
+pub(crate) struct MigrationTask {
+    pub(super) partition_range: (u64, u64), // (start_hash, end_hash)
+    pub(super) from_node: ReplicationId,
+    pub(super) to_node: ReplicationId,
+    pub(super) keys_to_migrate: Vec<String>, // actual keys in this range
+}

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -61,7 +61,7 @@ impl ClientController {
             },
             | ClientAction::Keys { pattern } => {
                 let res = self.cache_manager.route_keys(pattern).await;
-                QueryIO::Array(res.into_iter().map(|key| QueryIO::BulkString(key)).collect())
+                QueryIO::Array(res.into_iter().map(QueryIO::BulkString).collect())
             },
             | ClientAction::Config { key, value } => {
                 match (key.to_lowercase().as_str(), value.to_lowercase().as_str()) {

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -59,7 +59,7 @@ impl ClientController {
             | ClientAction::IndexGet { key, index } => {
                 self.cache_manager.route_index_get(key, index).await?.into()
             },
-            | ClientAction::Keys { pattern } => self.cache_manager.route_keys(pattern).await?,
+            | ClientAction::Keys { pattern } => self.cache_manager.route_keys(pattern).await,
             | ClientAction::Config { key, value } => {
                 match (key.to_lowercase().as_str(), value.to_lowercase().as_str()) {
                     | ("get", "dir") => format!("dir {}", ENV.dir).into(),

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -59,7 +59,10 @@ impl ClientController {
             | ClientAction::IndexGet { key, index } => {
                 self.cache_manager.route_index_get(key, index).await?.into()
             },
-            | ClientAction::Keys { pattern } => self.cache_manager.route_keys(pattern).await,
+            | ClientAction::Keys { pattern } => {
+                let res = self.cache_manager.route_keys(pattern).await;
+                QueryIO::Array(res.into_iter().map(|key| QueryIO::BulkString(key)).collect())
+            },
             | ClientAction::Config { key, value } => {
                 match (key.to_lowercase().as_str(), value.to_lowercase().as_str()) {
                     | ("get", "dir") => format!("dir {}", ENV.dir).into(),


### PR DESCRIPTION
`keys` operation is required for partitioning - which is `O(n)` operation but still okay as migration rarely happens 