### PR TITLE
feat: hashring multi shard leader update 

### DIFF
--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -460,10 +460,9 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         }
     }
 
-    #[instrument(level = tracing::Level::INFO, skip(self,cache_manager,cluster_handler), fields(request_from = %repl_leaders))]
+    #[instrument(level = tracing::Level::INFO, skip(self,cache_manager,cluster_handler))]
     pub(crate) async fn start_rebalance(
         &mut self,
-        repl_leaders: PeerIdentifier,
         cache_manager: &CacheManager,
         cluster_handler: Option<ClusterCommandHandler>,
     ) {

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -473,19 +473,9 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
             error!("Follower cannot start rebalance");
             return;
         }
-        let Some(member) = self.members.get(&repl_leaders) else {
-            error!("Received rebalance request from unknown peer: {}", repl_leaders);
-            return;
-        };
 
-        if member.is_replica(&self.replication.replid) {
-            error!("Cannot receive rebalance request from a replica: {}", repl_leaders);
-            return;
-        }
-
-        let Some(new_hash_ring) = self
-            .hash_ring
-            .add_partitions_if_not_exist(vec![(member.replid().clone(), member.id().clone())])
+        let Some(new_hash_ring) =
+            self.hash_ring.add_partitions_if_not_exist(self.shard_leaders().collect())
         else {
             return;
         };

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -158,7 +158,8 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
     pub(crate) fn follower_setup(&mut self, replid: ReplicationId, leader_id: PeerIdentifier) {
         self.set_repl_id(replid.clone());
         let hashring = HashRing::default();
-        let Some(new_hashring) = hashring.add_partition_if_not_exists(replid, leader_id) else {
+        let Some(new_hashring) = hashring.add_partitions_if_not_exist(vec![(replid, leader_id)])
+        else {
             return;
         };
         self.hash_ring = new_hashring;
@@ -185,10 +186,10 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
 
         let (tx, _) = tokio::sync::broadcast::channel::<Topology>(100);
         let hash_ring = HashRing::default()
-            .add_partition_if_not_exists(
+            .add_partitions_if_not_exist(vec![(
                 init_repl_state.replid.clone(),
                 init_repl_state.self_identifier(),
-            )
+            )])
             .unwrap();
 
         Self {
@@ -459,10 +460,10 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         }
     }
 
-    #[instrument(level = tracing::Level::INFO, skip(self,cache_manager,cluster_handler), fields(request_from = %request_from))]
+    #[instrument(level = tracing::Level::INFO, skip(self,cache_manager,cluster_handler), fields(request_from = %repl_leaders))]
     pub(crate) async fn start_rebalance(
         &mut self,
-        request_from: PeerIdentifier,
+        repl_leaders: PeerIdentifier,
         cache_manager: &CacheManager,
         cluster_handler: Option<ClusterCommandHandler>,
     ) {
@@ -472,19 +473,19 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
             error!("Follower cannot start rebalance");
             return;
         }
-        let Some(member) = self.members.get(&request_from) else {
-            error!("Received rebalance request from unknown peer: {}", request_from);
+        let Some(member) = self.members.get(&repl_leaders) else {
+            error!("Received rebalance request from unknown peer: {}", repl_leaders);
             return;
         };
 
         if member.is_replica(&self.replication.replid) {
-            error!("Cannot receive rebalance request from a replica: {}", request_from);
+            error!("Cannot receive rebalance request from a replica: {}", repl_leaders);
             return;
         }
 
         let Some(new_hash_ring) = self
             .hash_ring
-            .add_partition_if_not_exists(member.replid().clone(), member.id().clone())
+            .add_partitions_if_not_exist(vec![(member.replid().clone(), member.id().clone())])
         else {
             return;
         };

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -524,6 +524,13 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         })
     }
 
+    fn shard_leaders(&self) -> impl Iterator<Item = (ReplicationId, PeerIdentifier)> {
+        self.members
+            .iter()
+            .filter(|(_, peer)| peer.role() == ReplicationRole::Leader)
+            .map(|(id, peer)| (peer.replid().clone(), id.clone()))
+    }
+
     fn replicas_mut(&mut self) -> impl Iterator<Item = (&mut Peer, u64)> {
         self.members.values_mut().filter_map(|peer| {
             let match_index = peer.match_index();

--- a/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
@@ -11,19 +11,22 @@ async fn test_cluster_nodes() {
 
     // followers
     for port in [6379, 6380] {
-        cluster_actor.test_add_peer(port, None);
+        cluster_actor.test_add_peer(port, None, false);
     }
 
     // leader for different shard
     let second_shard_repl_id = ReplicationId::Key(uuid::Uuid::now_v7().to_string());
     let second_shard_leader_port = rand::random::<u16>();
 
-    let (_, second_shard_leader_identifier) =
-        cluster_actor.test_add_peer(second_shard_leader_port, Some(second_shard_repl_id.clone()));
+    let (_, second_shard_leader_identifier) = cluster_actor.test_add_peer(
+        second_shard_leader_port,
+        Some(second_shard_repl_id.clone()),
+        true,
+    );
 
     // follower for different shard
     for port in [2655, 2653] {
-        cluster_actor.test_add_peer(port, Some(second_shard_repl_id.clone()));
+        cluster_actor.test_add_peer(port, Some(second_shard_repl_id.clone()), false);
     }
 
     // WHEN
@@ -152,7 +155,7 @@ async fn test_topology_broadcast_on_hash_ring_change() {
 #[tokio::test]
 async fn test_update_cluster_members_updates_fields() {
     let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
-    let (_, peer_id) = cluster_actor.test_add_peer(6379, None);
+    let (_, peer_id) = cluster_actor.test_add_peer(6379, None, false);
     let initial = cluster_actor.members.get(&peer_id).unwrap();
 
     let initial_last_seen = initial.last_seen;
@@ -172,4 +175,59 @@ async fn test_update_cluster_members_updates_fields() {
     assert_eq!(updated.state().role, ReplicationRole::Leader);
     assert_ne!(updated.state().role, initial_role);
     assert!(updated.last_seen > initial_last_seen);
+}
+
+#[tokio::test]
+async fn test_shard_leaders() {
+    // GIVEN
+    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+
+    // Create different replication IDs for different shards
+    let shard1_replid = ReplicationId::Key("shard1".into());
+    let shard2_replid = ReplicationId::Key("shard2".into());
+    let shard3_replid = ReplicationId::Key("shard3".into());
+
+    // Add followers (should not be included in shard_leaders)
+    for port in [6379, 6380] {
+        cluster_actor.test_add_peer(port, Some(shard1_replid.clone()), false);
+    }
+
+    // Add leaders for different shards
+    let (_, leader1_id) = cluster_actor.test_add_peer(7001, Some(shard1_replid.clone()), true);
+    let (_, leader2_id) = cluster_actor.test_add_peer(7002, Some(shard2_replid.clone()), true);
+    let (_, leader3_id) = cluster_actor.test_add_peer(7003, Some(shard3_replid.clone()), true);
+
+    // WHEN
+    let shard_leaders: Vec<(ReplicationId, PeerIdentifier)> =
+        cluster_actor.shard_leaders().collect();
+
+    // THEN
+    assert_eq!(shard_leaders.len(), 3);
+
+    // Verify all expected leaders are present
+    let expected_leaders = vec![
+        (shard1_replid.clone(), leader1_id.clone()),
+        (shard2_replid.clone(), leader2_id.clone()),
+        (shard3_replid.clone(), leader3_id.clone()),
+    ];
+
+    for expected_leader in expected_leaders {
+        assert!(
+            shard_leaders.contains(&expected_leader),
+            "Expected leader {:?} not found in shard_leaders",
+            expected_leader
+        );
+    }
+
+    // Verify no followers are included
+    for (_replid, peer_id) in shard_leaders {
+        let peer = cluster_actor.members.get(&peer_id).unwrap();
+        assert_eq!(
+            peer.role(),
+            ReplicationRole::Leader,
+            "Peer {} should be a leader but has role {:?}",
+            peer_id,
+            peer.role()
+        );
+    }
 }

--- a/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
@@ -120,7 +120,7 @@ async fn test_topology_broadcast_on_hash_ring_change() {
 
     // Setup old ring
     let hash_ring = HashRing::default()
-        .add_partition_if_not_exists(replid.clone(), PeerIdentifier("peer1".into()))
+        .add_partitions_if_not_exist(vec![(replid.clone(), PeerIdentifier("peer1".into()))])
         .unwrap();
 
     cluster_actor.hash_ring = hash_ring.clone();

--- a/duva/src/domains/cluster_actors/actor/tests/elections.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/elections.rs
@@ -11,8 +11,8 @@ async fn test_run_for_election_transitions_to_candidate_and_sends_request_votes(
 
     let mut actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
     let initial_term = actor.replication.term;
-    let (fakebuf1, _) = actor.test_add_peer(8001, None);
-    let (fakebuf2, _) = actor.test_add_peer(8002, None);
+    let (fakebuf1, _) = actor.test_add_peer(8001, None, false);
+    let (fakebuf2, _) = actor.test_add_peer(8002, None, false);
 
     // WHEN: The actor runs for election
     actor.run_for_election().await;
@@ -64,7 +64,7 @@ async fn test_vote_election_grant_vote() {
     let mut follower_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
     let initial_term = follower_actor.replication.term;
 
-    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8011, None);
+    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8011, None, false);
 
     // Candidate's log is up-to-date or newer, and term is higher
     let request_vote = RequestVote {
@@ -109,7 +109,7 @@ async fn test_vote_election_deny_vote_older_log() {
         .await
         .unwrap(); // Follower log: idx 2, term 2
 
-    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8031, None);
+    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8031, None, false);
 
     let request_vote = RequestVote {
         // Candidate log: idx 1, term 2 (older)
@@ -141,7 +141,7 @@ async fn test_vote_election_deny_vote_lower_candidate_term() {
     let mut follower_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
     follower_actor.replication.term = follower_term;
 
-    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8031, None);
+    let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8031, None, false);
 
     let request_vote = RequestVote {
         term: follower_term - 1, // Candidate term is lower
@@ -175,7 +175,7 @@ async fn test_receive_election_vote_candidate_wins_election() {
     candidate_actor.replication.election_state = ElectionState::Candidate { voting: Some(voting) };
 
     // Add a mock replica to send initial heartbeat to
-    let (replica1_fake_buf, _) = candidate_actor.test_add_peer(8051, None);
+    let (replica1_fake_buf, _) = candidate_actor.test_add_peer(8051, None, false);
 
     let election_vote = ElectionVote { term: candidate_term, vote_granted: true };
 

--- a/duva/src/domains/cluster_actors/actor/tests/mod.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/mod.rs
@@ -247,6 +247,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         port: u16,
 
         repl_id: Option<ReplicationId>,
+        is_leader: bool,
     ) -> (FakeReadWrite, PeerIdentifier) {
         let buf = FakeReadWrite::new();
         let (id, peer) = create_peer_helper(
@@ -254,7 +255,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
             0,
             &repl_id.unwrap_or_else(|| self.replication.replid.clone()),
             port,
-            ReplicationRole::Follower,
+            if is_leader { ReplicationRole::Leader } else { ReplicationRole::Follower },
             buf.clone(),
         );
 

--- a/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
@@ -165,14 +165,12 @@ async fn test_maybe_update_hashring_when_noplan_is_made() {
     // Create hash ring for coordinating node
     let hash_ring = HashRing::default();
     let coordinator_replid = ReplicationId::Key(uuid::Uuid::now_v7().to_string());
+
     let hash_ring = hash_ring
-        .add_partition_if_not_exists(coordinator_replid, PeerIdentifier::new("127.0.0.1", 5999))
-        .unwrap();
-    let hash_ring = hash_ring
-        .add_partition_if_not_exists(
-            cluster_actor.replication.replid.clone(),
-            cluster_actor.replication.self_identifier(),
-        )
+        .add_partitions_if_not_exist(vec![
+            (coordinator_replid, PeerIdentifier::new("127.0.0.1", 5999)),
+            (cluster_actor.replication.replid.clone(), cluster_actor.replication.self_identifier()),
+        ])
         .unwrap();
 
     // WHEN
@@ -413,7 +411,7 @@ async fn test_receive_batch_success_path_when_consensus_is_required() {
     let (_, sender_peer_id) = cluster_actor.test_add_peer(6567, Some(peer_replid.clone()));
     cluster_actor.hash_ring = cluster_actor
         .hash_ring
-        .add_partition_if_not_exists(peer_replid.clone(), sender_peer_id.clone())
+        .add_partitions_if_not_exist(vec![(peer_replid.clone(), sender_peer_id.clone())])
         .unwrap();
 
     let cache_entries = cache_entries_create_helper(&[("success_key3", "value2")]);
@@ -452,7 +450,7 @@ async fn test_receive_batch_success_path_when_noreplica_found() {
     let (_, sender_peer_id) = cluster_actor.test_add_peer(6567, Some(peer_replid.clone()));
     cluster_actor.hash_ring = cluster_actor
         .hash_ring
-        .add_partition_if_not_exists(peer_replid.clone(), sender_peer_id.clone())
+        .add_partitions_if_not_exist(vec![(peer_replid.clone(), sender_peer_id.clone())])
         .unwrap();
 
     let cache_entries =
@@ -476,7 +474,10 @@ async fn test_receive_batch_validation_failure_keys_not_belonging_to_node() {
     let hash_ring = HashRing::default();
     let other_node_replid = ReplicationId::Key("other_node".to_string());
     let hash_ring = hash_ring
-        .add_partition_if_not_exists(other_node_replid, PeerIdentifier("127.0.0.1:5000".into()))
+        .add_partitions_if_not_exist(vec![(
+            other_node_replid,
+            PeerIdentifier("127.0.0.1:5000".into()),
+        )])
         .unwrap();
     cluster_actor.hash_ring = hash_ring;
 
@@ -769,12 +770,10 @@ async fn test_maybe_update_hashring_replica_only_updates_ring() {
     // Create a new hash ring with different configuration
     let new_node_replid = ReplicationId::Key("new_node".to_string());
     let new_ring = HashRing::default()
-        .add_partition_if_not_exists(new_node_replid, PeerIdentifier::new("127.0.0.1", 6000))
-        .unwrap()
-        .add_partition_if_not_exists(
-            cluster_actor.replication.replid.clone(),
-            cluster_actor.replication.self_identifier(),
-        )
+        .add_partitions_if_not_exist(vec![
+            (new_node_replid, PeerIdentifier::new("127.0.0.1", 6000)),
+            (cluster_actor.replication.replid.clone(), cluster_actor.replication.self_identifier()),
+        ])
         .unwrap();
 
     // WHEN - Replica receives hash ring update

--- a/duva/src/domains/cluster_actors/hash_ring/tests/mod.rs
+++ b/duva/src/domains/cluster_actors/hash_ring/tests/mod.rs
@@ -13,3 +13,10 @@ pub(crate) fn migration_task_create_helper(start_hash: u64, end_hash: u64) -> Mi
         keys_to_migrate: (start_hash..end_hash).map(|i| format!("key_{}", i)).collect(),
     }
 }
+
+fn replid_and_nodeid(port: u16) -> (ReplicationId, PeerIdentifier) {
+    (
+        ReplicationId::Key(uuid::Uuid::now_v7().to_string()),
+        PeerIdentifier(format!("127.0.0.1:{}", port)),
+    )
+}

--- a/duva/src/domains/cluster_actors/service.rs
+++ b/duva/src/domains/cluster_actors/service.rs
@@ -139,7 +139,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
                 self.receive_election_vote(request_vote_reply).await;
             },
             | StartRebalance => {
-                self.start_rebalance(from, cache_manager, None).await;
+                self.start_rebalance(cache_manager, None).await;
             },
             | ReceiveBatch(migrate_batch) => {
                 self.receive_batch(migrate_batch, cache_manager, from).await;

--- a/duva/src/domains/peers/peer.rs
+++ b/duva/src/domains/peers/peer.rs
@@ -54,6 +54,10 @@ impl Peer {
     pub(crate) fn set_role(&mut self, role: ReplicationRole) {
         self.state.role = role;
     }
+
+    pub(crate) fn role(&self) -> ReplicationRole {
+        self.state.role.clone()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]

--- a/duva/src/domains/query_io.rs
+++ b/duva/src/domains/query_io.rs
@@ -771,10 +771,10 @@ mod test {
     fn test_heartbeat_include_hashring() {
         // GIVEN
         let ring = HashRing::default()
-            .add_partition_if_not_exists(
+            .add_partitions_if_not_exist(vec![(
                 ReplicationId::Key(Uuid::now_v7().to_string()),
                 PeerIdentifier::new("127.0.1:3344".into(), 0),
-            )
+            )])
             .unwrap();
 
         let heartbeat = HeartBeat {


### PR DESCRIPTION
## Description
This PR refactors the hashring implementation to make it more robust and feature-rich in a multi-shard and multi-replica environment. The primary goal is to ensure that the hashring is always aware of the current shard leaders and that updates to the ring are handled in an idempotent manner. This is crucial for maintaining consistency and reliability in a distributed system where leadership changes and updates can occur frequently.



## Key Changes
- Multi-Replica Hashring Updates: The hashring has been updated to handle scenarios with multiple replicas, ensuring that the system can correctly manage and distribute data across them.
- Cluster Shards: The concept of cluster shards has been introduced or modified, which is a fundamental change in how data is partitioned and managed within the cluster.
- Leader-Aware Hashring: The hashring logic is now based on the current leaders of each shard. This ensures that read and write operations are always directed to the correct node, improving data consistency.
- Idempotent Updates: The process of updating the hashring has been made idempotent. This means that applying the same update multiple times will not have an adverse effect, which is a critical feature for ensuring stability in a distributed system where messages can be duplicated.

resolved #657 