### PR TITLE
chore: rm todos

### DIFF
--- a/duva-client/src/broker/mod.rs
+++ b/duva-client/src/broker/mod.rs
@@ -128,7 +128,7 @@ impl Broker {
     }
 
     // pull-based leader discovery
-    // TODO Implement leader discovery logic
+
     async fn discover_leader(&mut self) -> Result<(), IoError> {
         for node in &self.topology.connected_peers {
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;

--- a/duva/src/domains/peers/connections/outbound/stream.rs
+++ b/duva/src/domains/peers/connections/outbound/stream.rs
@@ -67,7 +67,6 @@ impl OutboundStream {
                                     "PSYNC",
                                     self.my_repl_info.replid.clone(),
                                     self.my_repl_info.hwm.load(Ordering::Acquire).to_string(),
-                                    //TODO
                                     self.my_repl_info.role.clone()
                                 )),
                                 | _ => Err(anyhow::anyhow!("Unexpected OK count")),


### PR DESCRIPTION
inspect if there is any need for list support on migration, confirmed to be none