### PR TITLE
fix: change hash ring update after migration done

### DIFF
--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -1269,6 +1269,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         });
     }
 
+    // New hash ring stored at this point with the current shard leaders
     pub(crate) fn unblock_write_reqs_if_done(&mut self) {
         let migrations_done = self.pending_migrations.as_ref().is_none_or(|p| p.is_empty());
 

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -1270,6 +1270,9 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         let migrations_done = self.pending_migrations.as_ref().is_none_or(|p| p.is_empty());
 
         if migrations_done {
+            if let Some(new_ring) = self.hash_ring.set_partitions(self.shard_leaders()) {
+                self.hash_ring = new_ring;
+            }
             let _ = self.node_change_broadcast.send(self.get_topology());
             if let Some(mut pending_reqs) = self.pending_requests.take() {
                 info!("All migrations complete, processing pending requests.");
@@ -1277,9 +1280,6 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
 
                 if pending_reqs.is_empty() {
                     return;
-                }
-                if let Some(new_ring) = self.hash_ring.set_partitions(self.shard_leaders()) {
-                    self.hash_ring = new_ring;
                 }
 
                 let handler = self.self_handler.clone();

--- a/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
@@ -149,7 +149,7 @@ async fn test_topology_broadcast_on_hash_ring_change() {
 
     // THEN
     let guard = topology.read().await;
-    assert_eq!(guard.hash_ring, hash_ring)
+    assert_ne!(guard.hash_ring, hash_ring)
 }
 
 #[tokio::test]


### PR DESCRIPTION
previous: update hash_ring after checking pending requests
after: migration is done → update hash_ring with new ring