### PR TITLE
fix: hash_ring update logic when cluster meet

### DIFF
--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -1195,13 +1195,6 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         ))
         .await;
 
-        // * If there are no replicas, we can directly apply the state
-        if self.replicas().count() == 0 {
-            let _ = rx.await;
-            cache_manager.route_mset(migrate_batch.cache_entries.clone()).await;
-            return;
-        }
-
         // * If there are replicas, we need to wait for the consensus to be applied which should be done in the background
         tokio::spawn({
             let handler = self.self_handler.clone();

--- a/duva/src/domains/cluster_actors/actor.rs
+++ b/duva/src/domains/cluster_actors/actor.rs
@@ -1071,6 +1071,7 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
         if migration_plans.is_empty() {
             info!("No migration tasks to schedule");
             self.hash_ring = *new_ring;
+            let _ = self.node_change_broadcast.send(self.get_topology());
             return;
         }
 


### PR DESCRIPTION
### Description

- Fix hash_ring update logic when there is no migration plan during cluster meet.
- Remove duplicated mget route which had early return