### PR TITLE
refactor: make cluster command eq check evaluatable

### DIFF
--- a/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
@@ -7,7 +7,7 @@ async fn test_cluster_nodes() {
     use std::io::Write;
 
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // followers
     for port in [6379, 6380] {
@@ -57,7 +57,7 @@ async fn test_cluster_nodes() {
 #[tokio::test]
 async fn test_store_current_topology() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let path = "test_store_current_topology.tp";
     cluster_actor.topology_writer = std::fs::File::create(path).unwrap();
 
@@ -80,7 +80,7 @@ async fn test_store_current_topology() {
 #[tokio::test]
 async fn test_reconnection_on_gossip() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // * run listener to see if connection is attempted
     let listener = TcpListener::bind("127.0.0.1:44455").await.unwrap(); // ! Beaware that this is cluster port
@@ -118,7 +118,7 @@ async fn test_reconnection_on_gossip() {
 async fn test_topology_broadcast_on_hash_ring_change() {
     // GIVEN
     let topology = Arc::new(RwLock::new(Topology::default()));
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let replid = ReplicationId::Key("node1".into());
 
     // Setup old ring
@@ -154,7 +154,7 @@ async fn test_topology_broadcast_on_hash_ring_change() {
 
 #[tokio::test]
 async fn test_update_cluster_members_updates_fields() {
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_, peer_id) = cluster_actor.test_add_peer(6379, None, false);
     let initial = cluster_actor.members.get(&peer_id).unwrap();
 
@@ -180,7 +180,7 @@ async fn test_update_cluster_members_updates_fields() {
 #[tokio::test]
 async fn test_shard_leaders() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // Create different replication IDs for different shards
     let shard1_replid = ReplicationId::Key("shard1".into());
@@ -221,11 +221,11 @@ async fn test_shard_leaders() {
 #[tokio::test]
 async fn test_add_peer_for_follower_send_heartbeat() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // Create a follower peer
     let buf = FakeReadWrite::new();
-    let (_, peer) = create_peer_helper(
+    let (_, peer) = Helper::create_peer(
         cluster_actor.self_handler.clone(),
         0,
         &cluster_actor.replication.replid.clone(),

--- a/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/cluster_managements.rs
@@ -238,7 +238,7 @@ async fn test_add_peer_for_follower_send_heartbeat() {
     let task = tokio::spawn(async move { rx.await.unwrap() });
 
     // WHEN - add the follower peer
-    cluster_actor.add_peer(peer, Some(tx)).await;
+    cluster_actor.add_peer(peer, Some(tx.into())).await;
 
     // THEN - check if heartbeat is sent to the follower
     task.await.unwrap().unwrap();

--- a/duva/src/domains/cluster_actors/actor/tests/elections.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/elections.rs
@@ -9,7 +9,7 @@ use crate::domains::peers::command::RequestVote;
 async fn test_run_for_election_transitions_to_candidate_and_sends_request_votes() {
     // GIVEN: A follower actor with a couple of replica peers
 
-    let mut actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     let initial_term = actor.replication.term;
     let (fakebuf1, _) = actor.test_add_peer(8001, None, false);
     let (fakebuf2, _) = actor.test_add_peer(8002, None, false);
@@ -41,7 +41,7 @@ async fn test_run_for_election_transitions_to_candidate_and_sends_request_votes(
 async fn test_run_for_election_no_replicas() {
     // GIVEN: A follower actor with no replicas
 
-    let mut actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     let initial_term = actor.replication.term;
 
     // WHEN: The actor runs for election
@@ -61,7 +61,7 @@ async fn test_run_for_election_no_replicas() {
 #[tokio::test]
 async fn test_vote_election_grant_vote() {
     // GIVEN: A follower actor
-    let mut follower_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut follower_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     let initial_term = follower_actor.replication.term;
 
     let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8011, None, false);
@@ -96,7 +96,7 @@ async fn test_vote_election_grant_vote() {
 #[tokio::test]
 async fn test_vote_election_deny_vote_older_log() {
     // GIVEN: A follower actor
-    let mut follower_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut follower_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     let initial_term = follower_actor.replication.term;
 
     follower_actor
@@ -138,7 +138,7 @@ async fn test_vote_election_deny_vote_older_log() {
 #[tokio::test]
 async fn test_vote_election_deny_vote_lower_candidate_term() {
     let follower_term = 3;
-    let mut follower_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut follower_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     follower_actor.replication.term = follower_term;
 
     let (candidate_fake_buf, candidate_id) = follower_actor.test_add_peer(8031, None, false);
@@ -165,7 +165,7 @@ async fn test_vote_election_deny_vote_lower_candidate_term() {
 async fn test_receive_election_vote_candidate_wins_election() {
     // GIVEN: A candidate actor needing one more vote to win (2 replicas + self = 3 total, needs 2 votes)
     let candidate_term = 3;
-    let mut candidate_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut candidate_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
     // Manually set up as candidate that has run for election
     candidate_actor.replication.term = candidate_term;
@@ -207,7 +207,7 @@ async fn test_receive_election_vote_candidate_wins_election() {
 #[tokio::test]
 async fn test_receive_election_vote_candidate_gets_vote_not_enough_to_win() {
     let candidate_term = 3;
-    let mut candidate_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut candidate_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     candidate_actor.replication.term = candidate_term;
 
     candidate_actor.replication.election_state =

--- a/duva/src/domains/cluster_actors/actor/tests/mod.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/mod.rs
@@ -76,6 +76,25 @@ impl TRead for FakeReadWrite {
 
 pub(crate) struct Helper;
 impl Helper {
+    // Helper function to create cache manager with hwm
+    pub(crate) fn cache_manager() -> (Arc<AtomicU64>, CacheManager) {
+        let hwm = Arc::new(AtomicU64::new(0));
+        let cache_manager = CacheManager::run_cache_actors(hwm.clone());
+        (hwm, cache_manager)
+    }
+
+    pub(crate) async fn cache_manager_with_keys(
+        keys: Vec<String>,
+    ) -> (Arc<AtomicU64>, CacheManager) {
+        let hwm = Arc::new(AtomicU64::new(0));
+        let cache_manager = CacheManager::run_cache_actors(hwm.clone());
+        for key in keys.clone() {
+            cache_manager.route_set(CacheEntry::new(key, "value"), 1).await.unwrap();
+        }
+        hwm.store(keys.len() as u64, Ordering::Relaxed);
+        (hwm, cache_manager)
+    }
+
     pub(crate) fn create_peer(
         cluster_sender: ClusterCommandHandler,
         hwm: u64,
@@ -210,25 +229,6 @@ impl InterceptedReceiver {
             }
         }
     }
-}
-
-// Helper function to create cache manager with hwm
-pub(crate) fn cache_manager_create_helper() -> (Arc<AtomicU64>, CacheManager) {
-    let hwm = Arc::new(AtomicU64::new(0));
-    let cache_manager = CacheManager::run_cache_actors(hwm.clone());
-    (hwm, cache_manager)
-}
-
-pub(crate) async fn cache_manager_create_helper_with_keys(
-    keys: Vec<String>,
-) -> (Arc<AtomicU64>, CacheManager) {
-    let hwm = Arc::new(AtomicU64::new(0));
-    let cache_manager = CacheManager::run_cache_actors(hwm.clone());
-    for key in keys.clone() {
-        cache_manager.route_set(CacheEntry::new(key, "value"), 1).await.unwrap();
-    }
-    hwm.store(keys.len() as u64, Ordering::Relaxed);
-    (hwm, cache_manager)
 }
 
 // Helper function to setup blocked cluster actor with pending requests

--- a/duva/src/domains/cluster_actors/actor/tests/mod.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/mod.rs
@@ -187,6 +187,17 @@ impl Helper {
             );
         }
     }
+
+    fn consensus_request(
+        tx: tokio::sync::oneshot::Sender<ConsensusClientResponse>,
+        session_req: Option<SessionRequest>,
+    ) -> ConsensusRequest {
+        ConsensusRequest::new(
+            WriteRequest::Set { key: "foo".into(), value: "bar".into(), expires_at: None },
+            Callback(tx),
+            session_req,
+        )
+    }
 }
 
 pub struct InterceptedReceiver(tokio::sync::mpsc::Receiver<ClusterCommand>);
@@ -199,17 +210,6 @@ impl InterceptedReceiver {
             }
         }
     }
-}
-
-fn consensus_request_create_helper(
-    tx: tokio::sync::oneshot::Sender<ConsensusClientResponse>,
-    session_req: Option<SessionRequest>,
-) -> ConsensusRequest {
-    ConsensusRequest::new(
-        WriteRequest::Set { key: "foo".into(), value: "bar".into(), expires_at: None },
-        Callback(tx),
-        session_req,
-    )
 }
 
 // Helper function to create cache manager with hwm
@@ -244,7 +244,7 @@ pub(crate) async fn setup_blocked_cluster_actor_with_requests(
             .pending_requests
             .as_mut()
             .unwrap()
-            .push_back(consensus_request_create_helper(tx, None));
+            .push_back(Helper::consensus_request(tx, None));
     }
 
     cluster_actor

--- a/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
@@ -88,7 +88,7 @@ async fn test_rebalance_request_happypath() {
 async fn test_start_rebalance_before_connection_is_made() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
 
     // WHEN
     let _ = cluster_actor.start_rebalance(&cache_manager).await;
@@ -103,7 +103,7 @@ async fn test_start_rebalance_before_connection_is_made() {
 async fn test_start_rebalance_only_when_replica_is_found() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     let (buf, _) = cluster_actor.test_add_peer(6559, None, false);
 
     // WHEN
@@ -119,7 +119,7 @@ async fn test_start_rebalance_only_when_replica_is_found() {
 async fn test_start_rebalance_happy_path() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     let (buf, _) = cluster_actor.test_add_peer(
         6559,
         Some(ReplicationId::Key(uuid::Uuid::now_v7().to_string())),
@@ -163,7 +163,7 @@ async fn test_maybe_update_hashring_when_noplan_is_made() {
         .unwrap();
 
     // WHEN
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     cluster_actor.maybe_update_hashring(Some(Box::new(hash_ring.clone())), &cache_manager).await;
 
     // THEN
@@ -179,7 +179,7 @@ async fn test_make_migration_plan_when_given_hashring_is_same() {
     let last_modified = cluster_actor.hash_ring.last_modified;
 
     // WHEN
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     cluster_actor
         .maybe_update_hashring(Some(Box::new(cluster_actor.hash_ring.clone())), &cache_manager)
         .await;
@@ -195,7 +195,7 @@ async fn test_make_migration_plan_when_no_hashring_given() {
     let last_modified = cluster_actor.hash_ring.last_modified;
 
     // WHEN
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     cluster_actor.maybe_update_hashring(None, &cache_manager).await;
 
     // THEN
@@ -306,7 +306,7 @@ async fn test_send_migrate_and_wait_callback_error() {
 async fn test_migrate_keys_target_peer_not_found() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
 
     let tasks = MigrationBatch::new(
         ReplicationId::Key("non_existent_peer".to_string()),
@@ -329,7 +329,7 @@ async fn test_migrate_keys_retrieves_actual_data() {
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     cluster_actor.block_write_reqs();
 
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     let target_repl_id = ReplicationId::Key("data_target".to_string());
     let (_, _) = cluster_actor.test_add_peer(6564, Some(target_repl_id.clone()), true);
 
@@ -367,7 +367,7 @@ async fn test_migrate_keys_retrieves_actual_data() {
 async fn test_receive_batch_success_path_when_consensus_is_required() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     let current_index = cluster_actor.logger.last_log_index;
     let peer_replid = ReplicationId::Key("repl_id_for_other_node".to_string());
 
@@ -409,7 +409,7 @@ async fn test_receive_batch_success_path_when_noreplica_found() {
     let (mut cluster_actor, recv) =
         Helper::cluster_actor_with_receiver(ReplicationRole::Leader).await;
 
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
     let current_index = cluster_actor.logger.last_log_index;
     let peer_replid = ReplicationId::Key("repl_id_for_other_node".to_string());
     let (_, sender_peer_id) = cluster_actor.test_add_peer(6567, Some(peer_replid.clone()), true);
@@ -526,7 +526,7 @@ async fn test_find_target_peer_for_replication() {
 async fn test_handle_migration_ack_failure() {
     // GIVEN
     let mut cluster_actor = setup_blocked_cluster_actor_with_requests(1).await;
-    let (_hwm, _cache_manager) = cache_manager_create_helper();
+    let (_hwm, _cache_manager) = Helper::cache_manager();
     let (callback, callback_rx) = tokio::sync::oneshot::channel();
     let batch_id = BatchId("failure_batch".into());
 
@@ -560,7 +560,7 @@ async fn test_handle_migration_ack_failure() {
 async fn test_handle_migration_ack_batch_id_not_found() {
     // GIVEN
     let mut cluster_actor = setup_blocked_cluster_actor_with_requests(1).await;
-    let (_hwm, _cache_manager) = cache_manager_create_helper();
+    let (_hwm, _cache_manager) = Helper::cache_manager();
     let (callback, _callback_rx) = tokio::sync::oneshot::channel();
     let existing_batch_id = BatchId("existing_batch".into());
     cluster_actor
@@ -591,7 +591,7 @@ async fn test_handle_migration_ack_success_case_with_pending_reqs_and_migration(
         true,
     );
 
-    let (_hwm, cache_manager) = cache_manager_create_helper();
+    let (_hwm, cache_manager) = Helper::cache_manager();
 
     // Set up test keys in cache that will be part of the migration
     let test_keys = vec!["migrate_key_1".to_string(), "migrate_key_2".to_string()];
@@ -652,11 +652,9 @@ async fn test_handle_migration_ack_success_case_with_pending_reqs_and_migration(
 async fn test_start_rebalance_schedules_migration_batches() {
     // GIVEN
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper_with_keys(vec![
-        "test_key_1".to_string(),
-        "test_key_2".to_string(),
-    ])
-    .await;
+    let (_hwm, cache_manager) =
+        Helper::cache_manager_with_keys(vec!["test_key_1".to_string(), "test_key_2".to_string()])
+            .await;
 
     // ! test_key_1 and test_key_2 are migrated to testnode_a
     let target_repl_id = ReplicationId::Key("testnode_a".into());
@@ -708,7 +706,7 @@ async fn test_start_rebalance_schedules_migration_batches() {
 async fn test_maybe_update_hashring_replica_only_updates_ring() {
     // GIVEN - Create a replica actor (not leader)
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
-    let (_hwm, cache_manager) = cache_manager_create_helper_with_keys(vec![
+    let (_hwm, cache_manager) = Helper::cache_manager_with_keys(vec![
         "replica_key_1".to_string(),
         "replica_key_2".to_string(),
     ])

--- a/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
@@ -13,7 +13,7 @@ use super::*;
 #[tokio::test]
 async fn test_rebalance_request_with_lazy() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // WHEN
     let request_to = PeerIdentifier("127.0.0.1:6559".into());
@@ -28,7 +28,7 @@ async fn test_rebalance_request_with_lazy() {
 #[tokio::test]
 async fn test_rebalance_request_before_member_connected() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // WHEN
     let request_to = PeerIdentifier("127.0.0.1:6559".into());
@@ -43,7 +43,7 @@ async fn test_rebalance_request_before_member_connected() {
 #[tokio::test]
 async fn test_rebalance_request_to_replica() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     let (buf, _) = cluster_actor.test_add_peer(6559, None, false);
 
@@ -66,7 +66,7 @@ async fn test_rebalance_request_to_replica() {
 #[tokio::test]
 async fn test_rebalance_request_happypath() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     let (buf, _) = cluster_actor.test_add_peer(
         6559,
@@ -87,7 +87,7 @@ async fn test_rebalance_request_happypath() {
 #[tokio::test]
 async fn test_start_rebalance_before_connection_is_made() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper();
 
     // WHEN
@@ -102,7 +102,7 @@ async fn test_start_rebalance_before_connection_is_made() {
 #[tokio::test]
 async fn test_start_rebalance_only_when_replica_is_found() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper();
     let (buf, _) = cluster_actor.test_add_peer(6559, None, false);
 
@@ -118,7 +118,7 @@ async fn test_start_rebalance_only_when_replica_is_found() {
 #[tokio::test]
 async fn test_start_rebalance_happy_path() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper();
     let (buf, _) = cluster_actor.test_add_peer(
         6559,
@@ -147,7 +147,7 @@ async fn test_start_rebalance_happy_path() {
 #[tokio::test]
 async fn test_maybe_update_hashring_when_noplan_is_made() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let last_modified = cluster_actor.hash_ring.last_modified;
     tokio::time::sleep(Duration::from_millis(1)).await; // sleep to make sure last_modified is updated
 
@@ -175,7 +175,7 @@ async fn test_maybe_update_hashring_when_noplan_is_made() {
 #[tokio::test]
 async fn test_make_migration_plan_when_given_hashring_is_same() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let last_modified = cluster_actor.hash_ring.last_modified;
 
     // WHEN
@@ -191,7 +191,7 @@ async fn test_make_migration_plan_when_given_hashring_is_same() {
 #[tokio::test]
 async fn test_make_migration_plan_when_no_hashring_given() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let last_modified = cluster_actor.hash_ring.last_modified;
 
     // WHEN
@@ -305,7 +305,7 @@ async fn test_send_migrate_and_wait_callback_error() {
 #[tokio::test]
 async fn test_migrate_keys_target_peer_not_found() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper();
 
     let tasks = MigrationBatch::new(
@@ -326,7 +326,7 @@ async fn test_migrate_keys_target_peer_not_found() {
 #[tokio::test]
 async fn test_migrate_keys_retrieves_actual_data() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     cluster_actor.block_write_reqs();
 
     let (_hwm, cache_manager) = cache_manager_create_helper();
@@ -366,7 +366,7 @@ async fn test_migrate_keys_retrieves_actual_data() {
 #[tokio::test]
 async fn test_receive_batch_success_path_when_consensus_is_required() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper();
     let current_index = cluster_actor.logger.last_log_index;
     let peer_replid = ReplicationId::Key("repl_id_for_other_node".to_string());
@@ -407,7 +407,7 @@ async fn test_receive_batch_success_path_when_consensus_is_required() {
 async fn test_receive_batch_success_path_when_noreplica_found() {
     // GIVEN
     let (mut cluster_actor, recv) =
-        cluster_actor_with_receiver_helper(ReplicationRole::Leader).await;
+        Helper::cluster_actor_with_receiver(ReplicationRole::Leader).await;
 
     let (_hwm, cache_manager) = cache_manager_create_helper();
     let current_index = cluster_actor.logger.last_log_index;
@@ -425,7 +425,6 @@ async fn test_receive_batch_success_path_when_noreplica_found() {
         batch_id: batch.batch_id.clone(),
         to: sender_peer_id.clone(),
     }));
-
     cluster_actor.receive_batch(batch, &cache_manager, sender_peer_id).await;
 
     // THEN - verify that the log index is incremented
@@ -476,7 +475,7 @@ async fn test_unblock_write_reqs_if_done_when_migrations_still_pending() {
 #[tokio::test]
 async fn test_unblock_write_reqs_if_done_when_not_blocked() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     cluster_actor.pending_migrations = Some(HashMap::new());
 
     // WHEN
@@ -507,7 +506,7 @@ async fn test_unblock_write_reqs_if_done_multiple_times() {
 #[tokio::test]
 async fn test_find_target_peer_for_replication() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let repl_id_1 = ReplicationId::Key("repl_1".to_string());
     let repl_id_2 = ReplicationId::Key("repl_2".to_string());
 
@@ -652,7 +651,7 @@ async fn test_handle_migration_ack_success_case_with_pending_reqs_and_migration(
 #[tokio::test]
 async fn test_start_rebalance_schedules_migration_batches() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (_hwm, cache_manager) = cache_manager_create_helper_with_keys(vec![
         "test_key_1".to_string(),
         "test_key_2".to_string(),
@@ -708,7 +707,7 @@ async fn test_start_rebalance_schedules_migration_batches() {
 #[tokio::test]
 async fn test_maybe_update_hashring_replica_only_updates_ring() {
     // GIVEN - Create a replica actor (not leader)
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     let (_hwm, cache_manager) = cache_manager_create_helper_with_keys(vec![
         "replica_key_1".to_string(),
         "replica_key_2".to_string(),

--- a/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/partitionings.rs
@@ -406,10 +406,8 @@ async fn test_receive_batch_success_path_when_consensus_is_required() {
 #[tokio::test]
 async fn test_receive_batch_success_path_when_noreplica_found() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
-    // ! intercept the channel to receive messages
-    let (tx, mut rx) = tokio::sync::mpsc::channel(10);
-    cluster_actor.self_handler = ClusterCommandHandler(tx);
+    let (mut cluster_actor, recv) =
+        cluster_actor_with_receiver_helper(ReplicationRole::Leader).await;
 
     let (_hwm, cache_manager) = cache_manager_create_helper();
     let current_index = cluster_actor.logger.last_log_index;
@@ -423,21 +421,11 @@ async fn test_receive_batch_success_path_when_noreplica_found() {
     let batch = migration_batch_create_helper("success_test", cache_entries.clone());
 
     // WHEN
-    let task = tokio::spawn({
-        let mig_batch = batch.clone();
-        let sender_peer_id = sender_peer_id.clone();
-        async move {
-            while let Some(msg) = rx.recv().await {
-                if let ClusterCommand::Scheduler(SchedulerMessage::SendBatchAck { batch_id, to }) =
-                    msg
-                {
-                    assert_eq!(batch_id, mig_batch.batch_id);
-                    assert_eq!(to, sender_peer_id);
-                    break;
-                }
-            }
-        }
-    });
+    let task = tokio::spawn(recv.wait_message(SchedulerMessage::SendBatchAck {
+        batch_id: batch.batch_id.clone(),
+        to: sender_peer_id.clone(),
+    }));
+
     cluster_actor.receive_batch(batch, &cache_manager, sender_peer_id).await;
 
     // THEN - verify that the log index is incremented

--- a/duva/src/domains/cluster_actors/actor/tests/replications.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/replications.rs
@@ -462,7 +462,8 @@ async fn req_consensus_inserts_consensus_voting() {
     let client_id = Uuid::now_v7();
     let session_request = SessionRequest::new(1, client_id);
     let w_req = WriteRequest::Set { key: "foo".into(), value: "bar".into(), expires_at: None };
-    let consensus_request = ConsensusRequest::new(w_req.clone(), tx, Some(session_request.clone()));
+    let consensus_request =
+        ConsensusRequest::new(w_req.clone(), Callback(tx), Some(session_request.clone()));
 
     // WHEN
     cluster_actor.req_consensus(consensus_request).await;
@@ -512,11 +513,11 @@ async fn test_leader_req_consensus_early_return_when_already_processed_session_r
     tokio::spawn(cluster_actor.handle(cache_manager));
     let (tx, rx) = tokio::sync::oneshot::channel();
     handler
-        .send(ClusterCommand::Client(ClientMessage::LeaderReqConsensus(ConsensusRequest {
-            request: WriteRequest::Set { key: "foo".into(), value: "bar".into(), expires_at: None },
-            callback: tx,
-            session_req: Some(client_req),
-        })))
+        .send(ClusterCommand::Client(ClientMessage::LeaderReqConsensus(ConsensusRequest::new(
+            WriteRequest::Set { key: "foo".into(), value: "bar".into(), expires_at: None },
+            tx,
+            Some(client_req),
+        ))))
         .await
         .unwrap();
 

--- a/duva/src/domains/cluster_actors/actor/tests/replications.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/replications.rs
@@ -6,9 +6,9 @@ fn logger_create_entries_from_lowest() {
     let mut logger = ReplicatedLogs::new(MemoryOpLogs::default(), 0, 0);
 
     let test_logs = vec![
-        sessionless_write_operation_helper(1, 0, "foo", "bar"),
-        sessionless_write_operation_helper(2, 0, "foo2", "bar"),
-        sessionless_write_operation_helper(3, 0, "foo3", "bar"),
+        Helper::write(1, 0, "foo", "bar"),
+        Helper::write(2, 0, "foo2", "bar"),
+        Helper::write(3, 0, "foo3", "bar"),
     ];
     logger.follower_write_entries(test_logs.clone()).unwrap();
 
@@ -38,7 +38,7 @@ fn logger_create_entries_from_lowest() {
 #[tokio::test]
 async fn test_generate_follower_entries() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let replid = cluster_actor.replication.replid.clone();
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
     let follower_buffs = (0..5).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
@@ -52,9 +52,9 @@ async fn test_generate_follower_entries() {
     );
 
     let test_logs = vec![
-        sessionless_write_operation_helper(1, 0, "foo", "bar"),
-        sessionless_write_operation_helper(2, 0, "foo2", "bar"),
-        sessionless_write_operation_helper(3, 0, "foo3", "bar"),
+        Helper::write(1, 0, "foo", "bar"),
+        Helper::write(2, 0, "foo2", "bar"),
+        Helper::write(3, 0, "foo3", "bar"),
     ];
 
     cluster_actor.replication.hwm.store(3, Ordering::Release);
@@ -94,15 +94,12 @@ async fn test_generate_follower_entries() {
 #[tokio::test]
 async fn follower_cluster_actor_replicate_log() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
     // WHEN - term
-    let heartbeat = heartbeat_create_helper(
+    let heartbeat = Helper::heartbeat(
         0,
         0,
-        vec![
-            sessionless_write_operation_helper(1, 0, "foo", "bar"),
-            sessionless_write_operation_helper(2, 0, "foo2", "bar"),
-        ],
+        vec![Helper::write(1, 0, "foo", "bar"), Helper::write(2, 0, "foo2", "bar")],
     );
     let cache_manager = CacheManager {
         inboxes: (0..10).map(|_| CacheCommandSender(channel(10).0)).collect::<Vec<_>>(),
@@ -130,15 +127,12 @@ async fn follower_cluster_actor_replicate_log() {
 async fn follower_cluster_actor_sessionless_replicate_state() {
     // GIVEN
     let (cache_handler, mut receiver) = tokio::sync::mpsc::channel(100);
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
-    let heartbeat = heartbeat_create_helper(
+    let heartbeat = Helper::heartbeat(
         0,
         0,
-        vec![
-            sessionless_write_operation_helper(1, 0, "foo", "bar"),
-            sessionless_write_operation_helper(2, 0, "foo2", "bar"),
-        ],
+        vec![Helper::write(1, 0, "foo", "bar"), Helper::write(2, 0, "foo2", "bar")],
     );
 
     let cache_manager = CacheManager { inboxes: vec![CacheCommandSender(cache_handler)] };
@@ -159,7 +153,7 @@ async fn follower_cluster_actor_sessionless_replicate_state() {
             }
         }
     });
-    let heartbeat = heartbeat_create_helper(0, 2, vec![]);
+    let heartbeat = Helper::heartbeat(0, 2, vec![]);
     cluster_actor.replicate(heartbeat, &cache_manager).await;
 
     // THEN
@@ -172,7 +166,7 @@ async fn follower_cluster_actor_sessionless_replicate_state() {
 async fn replicate_stores_only_latest_session_per_client() {
     // GIVEN
     let (cache_handler, _) = tokio::sync::mpsc::channel(100);
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
     let target_client = uuid::Uuid::now_v7();
     let session1 = SessionRequest::new(1, uuid::Uuid::now_v7());
@@ -180,13 +174,13 @@ async fn replicate_stores_only_latest_session_per_client() {
     // ! For the same client, hold only one request
     let session3 = SessionRequest::new(2, target_client);
 
-    let heartbeat = heartbeat_create_helper(
+    let heartbeat = Helper::heartbeat(
         0,
         0,
         vec![
-            sessionful_write_operation_helper(1, 0, "foo", "bar", session1.clone()),
-            sessionful_write_operation_helper(2, 0, "foo2", "bar", session2.clone()),
-            sessionful_write_operation_helper(3, 0, "foo2", "bar", session3.clone()),
+            Helper::session_write(1, 0, "foo", "bar", session1.clone()),
+            Helper::session_write(2, 0, "foo2", "bar", session2.clone()),
+            Helper::session_write(3, 0, "foo2", "bar", session3.clone()),
         ],
     );
 
@@ -202,16 +196,13 @@ async fn replicate_stores_only_latest_session_per_client() {
 #[tokio::test]
 async fn follower_cluster_actor_replicate_state_only_upto_hwm() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
     // Log two entries but don't commit them yet
-    let heartbeat = heartbeat_create_helper(
+    let heartbeat = Helper::heartbeat(
         0,
         0, // hwm=0, nothing committed yet
-        vec![
-            sessionless_write_operation_helper(1, 0, "foo", "bar"),
-            sessionless_write_operation_helper(2, 0, "foo2", "bar"),
-        ],
+        vec![Helper::write(1, 0, "foo", "bar"), Helper::write(2, 0, "foo2", "bar")],
     );
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
@@ -245,7 +236,7 @@ async fn follower_cluster_actor_replicate_state_only_upto_hwm() {
 
     // Send a heartbeat with hwm=1 to commit only the first entry
     const HWM: u64 = 1;
-    let heartbeat = heartbeat_create_helper(0, HWM, vec![]);
+    let heartbeat = Helper::heartbeat(0, HWM, vec![]);
     cluster_actor.replicate(heartbeat, &cache_manager).await;
 
     // THEN
@@ -263,16 +254,16 @@ async fn follower_cluster_actor_replicate_state_only_upto_hwm() {
 #[tokio::test]
 async fn test_apply_multiple_committed_entries() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
     // Add multiple entries
     let entries = vec![
-        sessionless_write_operation_helper(1, 0, "key1", "value1"),
-        sessionless_write_operation_helper(2, 0, "key2", "value2"),
-        sessionless_write_operation_helper(3, 0, "key3", "value3"),
+        Helper::write(1, 0, "key1", "value1"),
+        Helper::write(2, 0, "key2", "value2"),
+        Helper::write(3, 0, "key3", "value3"),
     ];
 
-    let heartbeat = heartbeat_create_helper(1, 0, entries);
+    let heartbeat = Helper::heartbeat(1, 0, entries);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
     let cache_manager = CacheManager { inboxes: vec![CacheCommandSender(tx)] };
@@ -297,7 +288,7 @@ async fn test_apply_multiple_committed_entries() {
     });
 
     // WHEN - commit all entries
-    let commit_heartbeat = heartbeat_create_helper(1, 3, vec![]);
+    let commit_heartbeat = Helper::heartbeat(1, 3, vec![]);
 
     cluster_actor.replicate(commit_heartbeat, &cache_manager).await;
 
@@ -315,15 +306,13 @@ async fn test_apply_multiple_committed_entries() {
 #[tokio::test]
 async fn test_partial_commit_with_new_entries() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Follower).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Follower).await;
 
     // First, append some entries
-    let first_entries = vec![
-        sessionless_write_operation_helper(1, 0, "key1", "value1"),
-        sessionless_write_operation_helper(2, 0, "key2", "value2"),
-    ];
+    let first_entries =
+        vec![Helper::write(1, 0, "key1", "value1"), Helper::write(2, 0, "key2", "value2")];
 
-    let first_heartbeat = heartbeat_create_helper(1, 0, first_entries);
+    let first_heartbeat = Helper::heartbeat(1, 0, first_entries);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
     let cache_manager = CacheManager { inboxes: vec![CacheCommandSender(tx)] };
@@ -347,9 +336,9 @@ async fn test_partial_commit_with_new_entries() {
     });
 
     // WHEN - commit partial entries and append new ones
-    let second_entries = vec![sessionless_write_operation_helper(3, 0, "key3", "value3")];
+    let second_entries = vec![Helper::write(3, 0, "key3", "value3")];
 
-    let second_heartbeat = heartbeat_create_helper(1, 1, second_entries);
+    let second_heartbeat = Helper::heartbeat(1, 1, second_entries);
 
     cluster_actor.replicate(second_heartbeat, &cache_manager).await;
 
@@ -371,23 +360,18 @@ async fn follower_truncates_log_on_term_mismatch() {
     let mut inmemory = MemoryOpLogs::default();
     //prefill
 
-    inmemory.writer.extend(vec![
-        sessionless_write_operation_helper(2, 1, "key1", "val1"),
-        sessionless_write_operation_helper(3, 1, "key2", "val2"),
-    ]);
+    inmemory
+        .writer
+        .extend(vec![Helper::write(2, 1, "key1", "val1"), Helper::write(3, 1, "key2", "val2")]);
 
     let logger = ReplicatedLogs::new(inmemory, 3, 1);
 
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     cluster_actor.logger = logger;
 
     // Simulate an initial log entry at index 1, term 1
     // WHEN: Leader sends an AppendEntries with prev_log_index=1, prev_log_term=2 (mismatch)
-    let mut heartbeat = heartbeat_create_helper(
-        2,
-        0,
-        vec![sessionless_write_operation_helper(4, 0, "key2", "val2")],
-    );
+    let mut heartbeat = Helper::heartbeat(2, 0, vec![Helper::write(4, 0, "key2", "val2")]);
     heartbeat.prev_log_term = 0;
     heartbeat.prev_log_index = 2;
 
@@ -402,14 +386,10 @@ async fn follower_truncates_log_on_term_mismatch() {
 async fn follower_accepts_entries_with_empty_log_and_prev_log_index_zero() {
     // GIVEN: A follower with an empty log
 
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // WHEN: Leader sends entries with prev_log_index=0
-    let mut heartbeat = heartbeat_create_helper(
-        1,
-        0,
-        vec![sessionless_write_operation_helper(1, 0, "key1", "val1")],
-    );
+    let mut heartbeat = Helper::heartbeat(1, 0, vec![Helper::write(1, 0, "key1", "val1")]);
 
     let result = cluster_actor.replicate_log_entries(&mut heartbeat).await;
 
@@ -422,14 +402,10 @@ async fn follower_accepts_entries_with_empty_log_and_prev_log_index_zero() {
 async fn follower_rejects_entries_with_empty_log_and_prev_log_index_nonzero() {
     // GIVEN: A follower with an empty log
 
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // WHEN: Leader sends entries with prev_log_index=1
-    let mut heartbeat = heartbeat_create_helper(
-        1,
-        0,
-        vec![sessionless_write_operation_helper(2, 0, "key2", "val2")],
-    );
+    let mut heartbeat = Helper::heartbeat(1, 0, vec![Helper::write(2, 0, "key2", "val2")]);
     heartbeat.prev_log_index = 1;
     heartbeat.prev_log_term = 1;
 
@@ -444,7 +420,7 @@ async fn follower_rejects_entries_with_empty_log_and_prev_log_index_nonzero() {
 async fn req_consensus_inserts_consensus_voting() {
     // GIVEN
 
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let replid = cluster_actor.replication.replid.clone();
     // - add 5 followers
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
@@ -500,7 +476,7 @@ async fn req_consensus_inserts_consensus_voting() {
 #[tokio::test]
 async fn test_leader_req_consensus_early_return_when_already_processed_session_req_given() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     let cache_manager = CacheManager { inboxes: vec![] };
 
@@ -528,7 +504,7 @@ async fn test_leader_req_consensus_early_return_when_already_processed_session_r
 #[tokio::test]
 async fn test_consensus_voting_deleted_when_consensus_reached() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let replid = cluster_actor.replication.replid.clone();
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
 
@@ -574,7 +550,7 @@ async fn test_consensus_voting_deleted_when_consensus_reached() {
 #[tokio::test]
 async fn test_same_voter_can_vote_only_once() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let replid = cluster_actor.replication.replid.clone();
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
 
@@ -613,7 +589,7 @@ async fn test_same_voter_can_vote_only_once() {
 #[tokio::test]
 async fn leader_consensus_tracker_not_changed_when_followers_not_exist() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (tx, _rx) = tokio::sync::oneshot::channel();
 
     let consensus_request = consensus_request_create_helper(tx, None);
@@ -629,7 +605,7 @@ async fn leader_consensus_tracker_not_changed_when_followers_not_exist() {
 #[tokio::test]
 async fn test_leader_req_consensus_with_pending_requests() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     // Block write requests to create pending requests queue
     cluster_actor.block_write_reqs();
@@ -652,7 +628,7 @@ async fn test_leader_req_consensus_with_pending_requests() {
 #[tokio::test]
 async fn test_leader_req_consensus_with_processed_session() {
     // GIVEN
-    let mut cluster_actor = cluster_actor_create_helper(ReplicationRole::Leader).await;
+    let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
 
     let client_id = Uuid::now_v7();
     let session_req = SessionRequest::new(1, client_id);

--- a/duva/src/domains/cluster_actors/actor/tests/replications.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/replications.rs
@@ -43,7 +43,7 @@ async fn test_generate_follower_entries() {
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
     let follower_buffs = (0..5).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
 
-    cluster_member_create_helper(
+    Helper::cluster_member(
         &mut cluster_actor,
         follower_buffs.clone(),
         ClusterCommandHandler(cluster_sender.clone()),
@@ -64,7 +64,7 @@ async fn test_generate_follower_entries() {
     //WHEN
     // *add lagged followers with its commit index being 1
     let follower_buffs = (5..7).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
-    cluster_member_create_helper(
+    Helper::cluster_member(
         &mut cluster_actor,
         follower_buffs,
         ClusterCommandHandler(cluster_sender),
@@ -426,7 +426,7 @@ async fn req_consensus_inserts_consensus_voting() {
     let (cluster_sender, _) = tokio::sync::mpsc::channel(100);
 
     let follower_buffs = (0..5).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
-    cluster_member_create_helper(
+    Helper::cluster_member(
         &mut cluster_actor,
         follower_buffs.clone(),
         ClusterCommandHandler(cluster_sender),
@@ -510,7 +510,7 @@ async fn test_consensus_voting_deleted_when_consensus_reached() {
 
     // - add 4 followers to create quorum - so 2 votes are needed to reach consensus
     let follower_buffs = (0..4).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
-    cluster_member_create_helper(
+    Helper::cluster_member(
         &mut cluster_actor,
         follower_buffs.clone(),
         ClusterCommandHandler(cluster_sender),
@@ -557,7 +557,7 @@ async fn test_same_voter_can_vote_only_once() {
     // - add followers to create quorum
 
     let follower_buffs = (0..4).map(|_| FakeReadWrite::new()).collect::<Vec<_>>();
-    cluster_member_create_helper(
+    Helper::cluster_member(
         &mut cluster_actor,
         follower_buffs.clone(),
         ClusterCommandHandler(cluster_sender),

--- a/duva/src/domains/cluster_actors/actor/tests/replications.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/replications.rs
@@ -522,7 +522,7 @@ async fn test_consensus_voting_deleted_when_consensus_reached() {
     let client_id = Uuid::now_v7();
     let client_request = SessionRequest::new(3, client_id);
     let consensus_request =
-        consensus_request_create_helper(client_request_sender, Some(client_request.clone()));
+        Helper::consensus_request(client_request_sender, Some(client_request.clone()));
 
     cluster_actor.req_consensus(consensus_request).await;
 
@@ -566,7 +566,7 @@ async fn test_same_voter_can_vote_only_once() {
     );
     let (client_request_sender, _client_wait) = tokio::sync::oneshot::channel();
 
-    let consensus_request = consensus_request_create_helper(client_request_sender, None);
+    let consensus_request = Helper::consensus_request(client_request_sender, None);
 
     cluster_actor.req_consensus(consensus_request).await;
 
@@ -592,7 +592,7 @@ async fn leader_consensus_tracker_not_changed_when_followers_not_exist() {
     let mut cluster_actor = Helper::cluster_actor(ReplicationRole::Leader).await;
     let (tx, _rx) = tokio::sync::oneshot::channel();
 
-    let consensus_request = consensus_request_create_helper(tx, None);
+    let consensus_request = Helper::consensus_request(tx, None);
 
     // WHEN
     cluster_actor.req_consensus(consensus_request).await;
@@ -613,7 +613,7 @@ async fn test_leader_req_consensus_with_pending_requests() {
     assert_eq!(cluster_actor.pending_requests.as_ref().unwrap().len(), 0);
 
     let (tx, _) = tokio::sync::oneshot::channel();
-    let consensus_request = consensus_request_create_helper(tx, None);
+    let consensus_request = Helper::consensus_request(tx, None);
 
     // WHEN - send request while write requests are blocked
     cluster_actor.leader_req_consensus(consensus_request).await;

--- a/duva/src/domains/cluster_actors/consensus/log.rs
+++ b/duva/src/domains/cluster_actors/consensus/log.rs
@@ -6,9 +6,9 @@ use crate::{
         peers::identifier::PeerIdentifier,
     },
     make_smart_pointer,
+    types::Callback,
 };
-use tokio::sync::oneshot::Sender;
-pub(crate) type ReplicationVote = Sender<ConsensusClientResponse>;
+pub(crate) type ReplicationVote = Callback<ConsensusClientResponse>;
 
 #[derive(Default, Debug)]
 pub struct LogConsensusTracker(pub(crate) HashMap<u64, LogConsensusVoting>);
@@ -66,8 +66,11 @@ mod tests {
         ];
 
         for (follower_count, expected_votes) in test_cases {
-            let voting =
-                LogConsensusVoting::new(tokio::sync::oneshot::channel().0, follower_count, None);
+            let voting = LogConsensusVoting::new(
+                tokio::sync::oneshot::channel().0.into(),
+                follower_count,
+                None,
+            );
             assert_eq!(voting.get_required_votes(), expected_votes);
         }
     }
@@ -77,7 +80,7 @@ mod tests {
         // Test with a large but safe number of followers
         let follower_count = 100;
         let voting =
-            LogConsensusVoting::new(tokio::sync::oneshot::channel().0, follower_count, None);
+            LogConsensusVoting::new(tokio::sync::oneshot::channel().0.into(), follower_count, None);
         let total_nodes = follower_count as u8 + 1;
         let expected_votes = (total_nodes + 1).div_ceil(2);
         assert_eq!(voting.get_required_votes(), expected_votes);

--- a/duva/src/domains/cluster_actors/hash_ring/migration_task.rs
+++ b/duva/src/domains/cluster_actors/hash_ring/migration_task.rs
@@ -1,4 +1,4 @@
-use crate::ReplicationId;
+use crate::{ReplicationId, types::Callback};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MigrationTask {
@@ -30,15 +30,15 @@ impl MigrationBatch {
 
 #[derive(Debug)]
 pub(crate) struct PendingMigrationBatch {
-    pub(crate) callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+    pub(crate) callback: Callback<anyhow::Result<()>>,
     pub(crate) keys: Vec<String>,
 }
 
 impl PendingMigrationBatch {
     pub(crate) fn new(
-        callback: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+        callback: impl Into<Callback<anyhow::Result<()>>>,
         keys: Vec<String>,
     ) -> Self {
-        Self { callback, keys }
+        Self { callback: callback.into(), keys }
     }
 }

--- a/duva/src/domains/cluster_actors/replication.rs
+++ b/duva/src/domains/cluster_actors/replication.rs
@@ -15,14 +15,11 @@ pub(crate) struct ReplicationState {
     pub(crate) replid: ReplicationId, // The replication ID of the master example: 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb
     pub(crate) hwm: Arc<AtomicU64>,   // high water mark (commit idx)
     pub(crate) role: ReplicationRole,
-
     pub(crate) self_host: String,
     pub(crate) self_port: u16,
-
     // * state is shared among peers
     pub(crate) term: u64,
     pub(crate) banlist: HashSet<BannedPeer>,
-
     pub(crate) election_state: ElectionState,
 }
 

--- a/duva/src/domains/peers/command.rs
+++ b/duva/src/domains/peers/command.rs
@@ -6,13 +6,13 @@ use crate::{
 
 pub(crate) use peer_messages::*;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct PeerCommand {
     pub(crate) from: PeerIdentifier,
     pub(crate) msg: PeerMessage,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PeerMessage {
     AppendEntriesRPC(HeartBeat),
     ClusterHeartBeat(HeartBeat),
@@ -61,7 +61,7 @@ mod peer_messages {
         peers::peer::PeerState,
     };
 
-    #[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+    #[derive(Clone, Debug, PartialEq, Eq, bincode::Encode, bincode::Decode)]
     pub struct RequestVote {
         pub(crate) term: u64, // current term of the candidate. Without it, the old leader wouldn't be able to step down gracefully.
         pub(crate) candidate_id: PeerIdentifier,
@@ -83,13 +83,13 @@ mod peer_messages {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+    #[derive(Clone, Debug, PartialEq, Eq, bincode::Encode, bincode::Decode)]
     pub struct ElectionVote {
         pub(crate) term: u64,
         pub(crate) vote_granted: bool,
     }
 
-    #[derive(Debug, Clone, PartialEq, bincode::Decode, bincode::Encode)]
+    #[derive(Debug, Clone, PartialEq, Eq, bincode::Decode, bincode::Encode)]
     pub struct ReplicationAck {
         pub(crate) log_idx: u64,
         pub(crate) term: u64,
@@ -97,7 +97,7 @@ mod peer_messages {
         pub(crate) from: PeerIdentifier,
     }
 
-    #[derive(Debug, Clone, PartialEq, bincode::Decode, bincode::Encode)]
+    #[derive(Debug, Clone, PartialEq, Eq, bincode::Decode, bincode::Encode)]
     pub(crate) enum RejectionReason {
         ReceiverHasHigherTerm,
         LogInconsistency,
@@ -137,7 +137,7 @@ mod peer_messages {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode, Default)]
+    #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode, Default)]
     pub struct HeartBeat {
         pub(crate) from: PeerIdentifier,
         pub(crate) term: u64,
@@ -189,13 +189,13 @@ mod peer_messages {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode)]
+    #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
     pub struct MigrateBatch {
         pub(crate) batch_id: BatchId,
         pub(crate) cache_entries: Vec<CacheEntry>,
     }
 
-    #[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode)]
+    #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
     pub struct MigrationBatchAck {
         pub(crate) batch_id: BatchId,
         pub(crate) success: bool,

--- a/duva/src/domains/peers/connections/connection_types.rs
+++ b/duva/src/domains/peers/connections/connection_types.rs
@@ -44,6 +44,13 @@ impl<T: TWrite> From<T> for WriteConnected {
     }
 }
 
+impl PartialEq for WriteConnected {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+impl Eq for WriteConnected {}
+
 #[derive(Debug)]
 pub(crate) struct ReadConnected(pub(crate) Box<dyn TRead>);
 make_smart_pointer!(ReadConnected, Box<dyn TRead>);

--- a/duva/src/domains/peers/connections/inbound/stream.rs
+++ b/duva/src/domains/peers/connections/inbound/stream.rs
@@ -15,9 +15,11 @@ use crate::domains::peers::identifier::PeerIdentifier;
 use crate::domains::peers::peer::Peer;
 use crate::domains::peers::peer::PeerState;
 use crate::domains::peers::service::PeerListener;
+
 use bytes::Bytes;
 use std::sync::atomic::Ordering;
 use tokio::net::TcpStream;
+
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::tcp::OwnedWriteHalf;
 

--- a/duva/src/domains/peers/connections/outbound/stream.rs
+++ b/duva/src/domains/peers/connections/outbound/stream.rs
@@ -12,6 +12,7 @@ use crate::domains::peers::identifier::PeerIdentifier;
 use crate::domains::peers::identifier::TPeerAddress;
 use crate::domains::peers::peer::Peer;
 use crate::domains::peers::service::PeerListener;
+use crate::types::Callback;
 use crate::write_array;
 use anyhow::Context;
 use bytes::Bytes;
@@ -102,7 +103,7 @@ impl OutboundStream {
         mut self,
         self_port: u16,
         cluster_handler: ClusterCommandHandler,
-        optional_callback: Option<tokio::sync::oneshot::Sender<anyhow::Result<()>>>,
+        optional_callback: Option<Callback<anyhow::Result<()>>>,
     ) -> anyhow::Result<()> {
         self.make_handshake(self_port).await?;
         let connection_info =

--- a/duva/src/domains/peers/service.rs
+++ b/duva/src/domains/peers/service.rs
@@ -32,7 +32,7 @@ impl PeerListener {
         let (kill_trigger, kill_switch) = tokio::sync::oneshot::channel();
         let handle = tokio::spawn(listener.listen(kill_switch));
 
-        ListeningActorKillTrigger::new(kill_trigger, handle)
+        ListeningActorKillTrigger::new(kill_trigger.into(), handle)
     }
 
     async fn read_command(&mut self) -> anyhow::Result<Vec<PeerMessage>> {

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -5,6 +5,7 @@ pub mod macros;
 pub mod presentation;
 mod types;
 use anyhow::Result;
+pub use config::Environment;
 use domains::IoError;
 use domains::caches::cache_manager::CacheManager;
 use domains::cluster_actors::ClusterActor;
@@ -12,19 +13,14 @@ use domains::cluster_actors::ConnectionMessage;
 use domains::cluster_actors::replication::ReplicationId;
 use domains::cluster_actors::replication::ReplicationRole;
 use domains::cluster_actors::replication::ReplicationState;
-
-pub use config::Environment;
 use domains::operation_logs::interfaces::TWriteAheadLog;
 use domains::saves::snapshot::Snapshot;
 use domains::saves::snapshot::snapshot_loader::SnapshotLoader;
 use presentation::clients::ClientController;
 use presentation::clients::authenticate;
-
 use presentation::clusters::communication_manager::ClusterCommunicationManager;
-
 use std::fs::File;
 use tokio::net::TcpListener;
-
 use tracing::debug;
 use tracing::error;
 use tracing::info;

--- a/duva/src/lib.rs
+++ b/duva/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 pub mod domains;
 pub mod macros;
 pub mod presentation;
+mod types;
 use anyhow::Result;
 use domains::IoError;
 use domains::caches::cache_manager::CacheManager;
@@ -143,7 +144,9 @@ impl StartUpFacade {
                 | Ok((peer_stream, socket_addr)) => {
                     debug!("Accepted peer connection: {}", socket_addr);
                     if cluster_communication_manager
-                        .send(ConnectionMessage::AcceptInboundPeer { stream: peer_stream })
+                        .send(ConnectionMessage::AcceptInboundPeer {
+                            stream: types::ConnectionStream(peer_stream),
+                        })
                         .await
                         .is_err()
                     {

--- a/duva/src/presentation/clusters/communication_manager.rs
+++ b/duva/src/presentation/clusters/communication_manager.rs
@@ -19,14 +19,14 @@ make_smart_pointer!(ClusterCommunicationManager, ClusterCommandHandler);
 impl ClusterCommunicationManager {
     pub(crate) async fn route_get_peers(&self) -> anyhow::Result<Vec<PeerIdentifier>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClientMessage::GetPeers(tx)).await?;
+        self.send(ClientMessage::GetPeers(tx.into())).await?;
         let peers = rx.await?;
         Ok(peers)
     }
 
     pub(crate) async fn route_get_topology(&self) -> anyhow::Result<Topology> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClientMessage::GetTopology(tx)).await?;
+        self.send(ClientMessage::GetTopology(tx.into())).await?;
         let peers = rx.await?;
         Ok(peers)
     }
@@ -36,14 +36,14 @@ impl ClusterCommunicationManager {
         connect_to: PeerIdentifier,
     ) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ConnectionMessage::ConnectToServer { connect_to, callback: tx }).await?;
+        self.send(ConnectionMessage::ConnectToServer { connect_to, callback: tx.into() }).await?;
         rx.await??;
         Ok(())
     }
 
     pub(crate) async fn route_get_replication_state(&self) -> anyhow::Result<ReplicationState> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClientMessage::ReplicationInfo(tx)).await?;
+        self.send(ClientMessage::ReplicationInfo(tx.into())).await?;
         Ok(rx.await?)
     }
 
@@ -69,7 +69,7 @@ impl ClusterCommunicationManager {
         peer_identifier: PeerIdentifier,
     ) -> anyhow::Result<bool> {
         let (tx, rx) = tokio::sync::oneshot::channel::<Option<()>>();
-        self.send(ClientMessage::ForgetPeer(peer_identifier, tx)).await?;
+        self.send(ClientMessage::ForgetPeer(peer_identifier, tx.into())).await?;
         let Some(_) = rx.await? else { return Ok(false) };
         Ok(true)
     }
@@ -79,7 +79,7 @@ impl ClusterCommunicationManager {
         peer_identifier: PeerIdentifier,
     ) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self.send(ClientMessage::ReplicaOf(peer_identifier, tx)).await;
+        let _ = self.send(ClientMessage::ReplicaOf(peer_identifier, tx.into())).await;
 
         rx.await?
     }
@@ -90,24 +90,25 @@ impl ClusterCommunicationManager {
         lazy_option: LazyOption,
     ) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self.send(ClientMessage::ClusterMeet(peer_identifier, lazy_option, tx)).await;
+        let _ =
+            self.send(ClientMessage::ClusterMeet(peer_identifier, lazy_option, tx.into())).await;
         rx.await?
     }
     pub(crate) async fn route_cluster_reshard(&self) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self.send(ClientMessage::ClusterReshard(tx)).await;
+        let _ = self.send(ClientMessage::ClusterReshard(tx.into())).await;
         rx.await?
     }
 
     pub(crate) async fn route_cluster_nodes(&self) -> anyhow::Result<Vec<PeerState>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClientMessage::ClusterNodes(tx)).await?;
+        self.send(ClientMessage::ClusterNodes(tx.into())).await?;
         Ok(rx.await?)
     }
 
     pub(crate) async fn route_get_role(&self) -> anyhow::Result<ReplicationRole> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.send(ClientMessage::GetRole(tx)).await?;
+        self.send(ClientMessage::GetRole(tx.into())).await?;
         Ok(rx.await?)
     }
 
@@ -115,7 +116,7 @@ impl ClusterCommunicationManager {
         &self,
     ) -> anyhow::Result<tokio::sync::broadcast::Receiver<Topology>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ = self.send(ClientMessage::SubscribeToTopologyChange(tx)).await;
+        let _ = self.send(ClientMessage::SubscribeToTopologyChange(tx.into())).await;
         Ok(rx.await?)
     }
 }

--- a/duva/src/types.rs
+++ b/duva/src/types.rs
@@ -1,0 +1,37 @@
+use tokio::net::TcpStream;
+
+#[derive(Debug)]
+pub(crate) struct Callback<T>(pub(crate) tokio::sync::oneshot::Sender<T>);
+impl<T> Callback<T> {
+    pub(crate) fn send(self, value: T) -> Result<(), T> {
+        self.0.send(value)
+    }
+}
+
+impl<T> From<tokio::sync::oneshot::Sender<T>> for Callback<T> {
+    fn from(sender: tokio::sync::oneshot::Sender<T>) -> Self {
+        Callback(sender)
+    }
+}
+
+impl<T> PartialEq for Callback<T> {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+impl<T> Eq for Callback<T> {}
+
+#[derive(Debug)]
+pub(crate) struct ConnectionStream(pub(crate) TcpStream);
+impl PartialEq for ConnectionStream {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.peer_addr().unwrap() == other.0.peer_addr().unwrap()
+    }
+}
+impl Eq for ConnectionStream {}
+
+impl From<TcpStream> for ConnectionStream {
+    fn from(stream: TcpStream) -> Self {
+        ConnectionStream(stream)
+    }
+}


### PR DESCRIPTION
- test: send SchedulerMessage::SendBatchAck  #712 
- enum comparison on message
- `Helper` added
- `Callback` added
