### PR TITLE
feat: lpop 

### DIFF
--- a/duva-client/src/controller.rs
+++ b/duva-client/src/controller.rs
@@ -104,9 +104,13 @@ impl<T> ClientController<T> {
                 | _ => Response::FormatError,
             },
             | Keys { .. } | MGet { .. } | LPop { .. } => {
+                if let QueryIO::Null = query_io {
+                    return Response::Null;
+                }
                 let QueryIO::Array(value) = query_io else {
                     return Response::FormatError;
                 };
+
                 let mut keys = Vec::new();
                 for (i, item) in value.into_iter().enumerate() {
                     let QueryIO::BulkString(value) = item else {

--- a/duva-client/src/controller.rs
+++ b/duva-client/src/controller.rs
@@ -103,7 +103,7 @@ impl<T> ClientController<T> {
                 | QueryIO::Err(value) => Response::Error(value),
                 | _ => Response::FormatError,
             },
-            | Keys { .. } | MGet { .. } => {
+            | Keys { .. } | MGet { .. } | LPop { .. } => {
                 let QueryIO::Array(value) = query_io else {
                     return Response::FormatError;
                 };

--- a/duva/src/domains/caches/actor.rs
+++ b/duva/src/domains/caches/actor.rs
@@ -117,13 +117,17 @@ impl CacheActor {
     }
 
     pub(crate) fn lpop(&mut self, key: String, count: usize) -> Vec<String> {
-        let val = self.cache.get(&key);
-        if let Some(CacheValue { value: TypedValue::List(list), .. }) = val {
-            (0..count)
+        let val = self.cache.remove(&key);
+        if let Some(CacheValue { value: TypedValue::List(mut list), .. }) = val {
+            let vals = (0..count)
                 .filter_map(|_| list.lpop()) // Convert to Iterator<Item = Bytes>
                 .map(|v| String::from_utf8(v.to_vec())) // Convert to Iterator<Item= Result<String>>
                 .flatten()
-                .collect()
+                .collect();
+            if list.llen() != 0 {
+                self.cache.put(key, CacheValue::new(TypedValue::List(list)));
+            }
+            vals
         } else {
             vec![]
         }

--- a/duva/src/domains/caches/actor.rs
+++ b/duva/src/domains/caches/actor.rs
@@ -115,6 +115,19 @@ impl CacheActor {
 
         Ok(list.llen())
     }
+
+    pub(crate) fn lpop(&mut self, key: String, count: usize) -> Vec<String> {
+        let val = self.cache.get(&key);
+        if let Some(CacheValue { value: TypedValue::List(list), .. }) = val {
+            (0..count)
+                .filter_map(|_| list.lpop()) // Convert to Iterator<Item = Bytes>
+                .map(|v| String::from_utf8(v.to_vec())) // Convert to Iterator<Item= Result<String>>
+                .flatten()
+                .collect()
+        } else {
+            vec![]
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/duva/src/domains/caches/cache_manager.rs
+++ b/duva/src/domains/caches/cache_manager.rs
@@ -137,6 +137,9 @@ impl CacheManager {
             | WriteRequest::LPush { key, value } => {
                 self.route_lpush(key, value, log_index).await?;
             },
+            | WriteRequest::LPop { key, count } => {
+                self.route_lpop(key, count).await;
+            },
         };
 
         // * This is to wake up the cache actors to process the pending read requests
@@ -316,6 +319,10 @@ impl CacheManager {
             .await?;
         let current = rx.await?;
         Ok(IndexedValueCodec::encode(current?, current_idx))
+    }
+
+    async fn route_lpop(&self, key: String, count: usize) -> Vec<String> {
+        todo!()
     }
 }
 

--- a/duva/src/domains/caches/command.rs
+++ b/duva/src/domains/caches/command.rs
@@ -15,4 +15,5 @@ pub(crate) enum CacheCommand {
     Append { key: String, value: String, callback: oneshot::Sender<anyhow::Result<usize>> },
     NumericDetla { key: String, delta: i64, callback: oneshot::Sender<anyhow::Result<i64>> },
     LPush { key: String, values: Vec<String>, callback: Callback<anyhow::Result<usize>> },
+    LPop { key: String, count: usize, callback: Callback<Vec<String>> },
 }

--- a/duva/src/domains/caches/lru_cache.rs
+++ b/duva/src/domains/caches/lru_cache.rs
@@ -160,17 +160,17 @@ impl<K: Eq + Hash + Clone + Debug, V: Debug + Clone + THasExpiry> LruCache<K, V>
         self.head = Some(index);
     }
 
-    pub fn get<Q>(&mut self, key: &Q) -> Option<&mut V>
+    pub fn get<Q>(&mut self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let Some(index) = self.map.get_mut(key) else {
+        let Some(index) = self.map.get(key) else {
             return None;
         };
         let index = *index;
         self.move_to_head(index);
-        Some(&mut self.slab.get_mut(index).expect("Node not found").value)
+        Some(&self.slab.get(index).expect("Node not found").value)
     }
 
     pub fn clear(&mut self) {
@@ -343,18 +343,18 @@ mod tests {
         cache.put(1, "one");
         cache.put(2, "two");
 
-        assert_eq!(cache.get(&1), Some(&mut "one")); // 1 is now MRU
-        assert_eq!(cache.get(&2), Some(&mut "two")); // 2 is now MRU (list: 2 -> 1)
+        assert_eq!(cache.get(&1), Some(&"one")); // 1 is now MRU
+        assert_eq!(cache.get(&2), Some(&"two")); // 2 is now MRU (list: 2 -> 1)
 
         cache.put(3, "three"); // Evicts 1 (LRU)
         assert_eq!(cache.get(&1), None);
-        assert_eq!(cache.get(&2), Some(&mut "two")); // 2 is now LRU
-        assert_eq!(cache.get(&3), Some(&mut "three")); // 3 is MRU (list: 3 -> 2)
+        assert_eq!(cache.get(&2), Some(&"two")); // 2 is now LRU
+        assert_eq!(cache.get(&3), Some(&"three")); // 3 is MRU (list: 3 -> 2)
 
         cache.put(4, "four"); // Evicts 2 (LRU)
         assert_eq!(cache.get(&2), None);
-        assert_eq!(cache.get(&3), Some(&mut "three")); // 3 is LRU
-        assert_eq!(cache.get(&4), Some(&mut "four")); // 4 is MRU (list: 4 -> 3)
+        assert_eq!(cache.get(&3), Some(&"three")); // 3 is LRU
+        assert_eq!(cache.get(&4), Some(&"four")); // 4 is MRU (list: 4 -> 3)
     }
 
     #[test]
@@ -363,30 +363,30 @@ mod tests {
         cache.put(1, "one");
         cache.put(2, "two");
 
-        assert_eq!(cache.get(&1), Some(&mut "one")); // 1 is now MRU
+        assert_eq!(cache.get(&1), Some(&"one")); // 1 is now MRU
 
         cache.put(2, "updated_two"); // Update value, 2 becomes MRU. List: 2 -> 1
-        assert_eq!(cache.get(&2), Some(&mut "updated_two")); // 2 is now MRU
-        assert_eq!(cache.get(&1), Some(&mut "one")); // 1 is now MRU
+        assert_eq!(cache.get(&2), Some(&"updated_two")); // 2 is now MRU
+        assert_eq!(cache.get(&1), Some(&"one")); // 1 is now MRU
 
         cache.put(3, "three"); // Evicts 2. List: 3 -> 1
         assert_eq!(cache.get(&2), None);
-        assert_eq!(cache.get(&1), Some(&mut "one")); // 1 is now MRU
-        assert_eq!(cache.get(&3), Some(&mut "three"));
+        assert_eq!(cache.get(&1), Some(&"one")); // 1 is now MRU
+        assert_eq!(cache.get(&3), Some(&"three"));
     }
 
     #[test]
     fn test_lru_capacity_one() {
         let mut cache = LruCache::new(1);
         cache.put(1, "one");
-        assert_eq!(cache.get(&1), Some(&mut "one"));
+        assert_eq!(cache.get(&1), Some(&"one"));
 
         cache.put(2, "two"); // Evicts 1
         assert_eq!(cache.get(&1), None);
-        assert_eq!(cache.get(&2), Some(&mut "two"));
+        assert_eq!(cache.get(&2), Some(&"two"));
 
         cache.put(2, "updated_two"); // Update existing
-        assert_eq!(cache.get(&2), Some(&mut "updated_two")); // Still "two"
+        assert_eq!(cache.get(&2), Some(&"updated_two")); // Still "two"
     }
 
     #[test]
@@ -412,8 +412,8 @@ mod tests {
         assert_eq!(cache.len(), 2);
 
         // Remaining keys should still be accessible
-        assert_eq!(cache.get(&1), Some(&mut "one"));
-        assert_eq!(cache.get(&3), Some(&mut "three"));
+        assert_eq!(cache.get(&1), Some(&"one"));
+        assert_eq!(cache.get(&3), Some(&"three"));
     }
 
     #[test]
@@ -514,7 +514,7 @@ mod tests {
         assert_eq!(cache.len(), 1);
 
         // Verify it was actually inserted
-        assert_eq!(cache.get(&1), Some(&mut "one"));
+        assert_eq!(cache.get(&1), Some(&"one"));
     }
 
     #[test]
@@ -528,7 +528,7 @@ mod tests {
         assert_eq!(cache.len(), 1);
 
         // Verify original value is unchanged
-        assert_eq!(cache.get(&1), Some(&mut "original"));
+        assert_eq!(cache.get(&1), Some(&"original"));
     }
 
     #[test]
@@ -557,7 +557,7 @@ mod tests {
         }
 
         // Verify modification persisted
-        assert_eq!(cache.get(&1), Some(&mut CacheValue::new("modified")));
+        assert_eq!(cache.get(&1), Some(&CacheValue::new("modified")));
     }
 
     #[test]
@@ -581,9 +581,9 @@ mod tests {
 
         // Verify state
         assert_eq!(cache.len(), 2);
-        assert_eq!(cache.get(&1), Some(&mut CacheValue::new("one_modified")));
+        assert_eq!(cache.get(&1), Some(&CacheValue::new("one_modified")));
         assert_eq!(cache.get(&2), None); // Should be evicted
-        assert_eq!(cache.get(&3), Some(&mut CacheValue::new("three")));
+        assert_eq!(cache.get(&3), Some(&CacheValue::new("three")));
     }
 
     #[test]

--- a/duva/src/domains/caches/service.rs
+++ b/duva/src/domains/caches/service.rs
@@ -70,7 +70,9 @@ impl CacheActor {
                 | CacheCommand::LPush { key, values, callback } => {
                     let _ = callback.send(self.lpush(key, values));
                 },
-                | CacheCommand::LPop { key, count, callback } => todo!(),
+                | CacheCommand::LPop { key, count, callback } => {
+                    let _ = callback.send(self.lpop(key, count));
+                },
             }
         }
         Ok(self)

--- a/duva/src/domains/caches/service.rs
+++ b/duva/src/domains/caches/service.rs
@@ -70,6 +70,7 @@ impl CacheActor {
                 | CacheCommand::LPush { key, values, callback } => {
                     let _ = callback.send(self.lpush(key, values));
                 },
+                | CacheCommand::LPop { key, count, callback } => todo!(),
             }
         }
         Ok(self)

--- a/duva/src/domains/operation_logs/operation.rs
+++ b/duva/src/domains/operation_logs/operation.rs
@@ -22,6 +22,7 @@ pub enum WriteRequest {
     Decr { key: String, delta: i64 },
     Incr { key: String, delta: i64 },
     LPush { key: String, value: Vec<String> },
+    LPop { key: String, count: usize },
 }
 
 impl WriteOperation {
@@ -58,6 +59,7 @@ impl WriteRequest {
             | WriteRequest::Delete { keys, .. } => keys.iter().map(|k| k.as_str()).collect(),
             | WriteRequest::MSet { entries } => entries.iter().map(|e| e.key()).collect(),
             | WriteRequest::LPush { key, .. } => vec![key],
+            | WriteRequest::LPop { key, .. } => vec![key],
         }
     }
 }

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -99,7 +99,6 @@ impl ClientController {
             | ClientAction::Exists { keys } => QueryIO::SimpleString(
                 self.cache_manager.route_exists(keys).await?.to_string().into(),
             ),
-
             | ClientAction::Info => QueryIO::BulkString(
                 self.cluster_communication_manager
                     .route_get_replication_state()
@@ -172,6 +171,7 @@ impl ClientController {
             | ClientAction::LPush { key, value } => QueryIO::SimpleString(
                 self.cache_manager.route_lpush(key, value, current_index.unwrap()).await?.into(),
             ),
+            | ClientAction::LPop { key, count } => todo!(),
         };
 
         Ok(response)

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -173,6 +173,9 @@ impl ClientController {
             ),
             | ClientAction::LPop { key, count } => {
                 let values = self.cache_manager.route_lpop(key, count).await?;
+                if values.is_empty() {
+                    return Ok(QueryIO::Null);
+                }
                 QueryIO::Array(values.into_iter().map(|v| QueryIO::BulkString(v.into())).collect())
             },
         };

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -171,7 +171,10 @@ impl ClientController {
             | ClientAction::LPush { key, value } => QueryIO::SimpleString(
                 self.cache_manager.route_lpush(key, value, current_index.unwrap()).await?.into(),
             ),
-            | ClientAction::LPop { key, count } => todo!(),
+            | ClientAction::LPop { key, count } => {
+                let values = self.cache_manager.route_lpop(key, count).await?;
+                QueryIO::Array(values.into_iter().map(|v| QueryIO::BulkString(v.into())).collect())
+            },
         };
 
         Ok(response)

--- a/duva/src/presentation/clients/request.rs
+++ b/duva/src/presentation/clients/request.rs
@@ -63,6 +63,7 @@ impl ClientAction {
                 WriteRequest::Decr { key, delta: decrement }
             },
             | ClientAction::LPush { key, value } => WriteRequest::LPush { key, value },
+            | ClientAction::LPop { key, count } => WriteRequest::LPop { key, count },
 
             | _ => {
                 debug_assert!(false, "to_write_request called on non-write action: {self:?}");
@@ -73,6 +74,7 @@ impl ClientAction {
         }
     }
 
+    // TODO refactor the following in a way that's merged with to_write_request?
     pub fn consensus_required(&self) -> bool {
         matches!(
             self,
@@ -85,6 +87,7 @@ impl ClientAction {
                 | ClientAction::IncrBy { .. }
                 | ClientAction::DecrBy { .. }
                 | ClientAction::LPush { .. }
+                | ClientAction::LPop { .. }
         )
     }
 }

--- a/duva/src/presentation/clients/request.rs
+++ b/duva/src/presentation/clients/request.rs
@@ -38,6 +38,7 @@ pub enum ClientAction {
     IncrBy { key: String, increment: i64 },
     DecrBy { key: String, decrement: i64 },
     LPush { key: String, value: Vec<String> },
+    LPop { key: String, count: usize },
 }
 
 impl ClientAction {
@@ -301,6 +302,12 @@ pub fn extract_action(action: &str, args: &[&str]) -> anyhow::Result<ClientActio
             let key = args[0].to_string();
             let values = args[1..].iter().map(|s| s.to_string()).collect();
             Ok(ClientAction::LPush { key, value: values })
+        },
+        | "LPOP" => {
+            require_non_empty_args()?;
+            let key = args[0].to_string();
+            let count = args.get(1).and_then(|s| s.parse::<usize>().ok()).unwrap_or(1);
+            Ok(ClientAction::LPop { key, count })
         },
         // Add other commands as needed
         | unknown_cmd => Err(anyhow::anyhow!(

--- a/duva/tests/client_ops/mod.rs
+++ b/duva/tests/client_ops/mod.rs
@@ -8,6 +8,7 @@ mod test_decrby;
 mod test_incr;
 mod test_incrby;
 mod test_keys;
+mod test_lpop;
 mod test_lpush;
 mod test_replication_info;
 mod test_set_get;

--- a/duva/tests/client_ops/test_lpop.rs
+++ b/duva/tests/client_ops/test_lpop.rs
@@ -1,0 +1,37 @@
+use crate::common::{Client, ServerEnv, spawn_server_process};
+
+fn run_lpop(env: ServerEnv) -> anyhow::Result<()> {
+    // GIVEN
+    let process = spawn_server_process(&env)?;
+
+    let mut h = Client::new(process.port);
+    let res = h.send_and_get(format!("LPUSH test 1 2 3 4 5"));
+    assert_eq!(res, "(integer) 5");
+
+    //WHEN & ASSERT
+    assert_eq!(h.send_and_get(format!("LPOP test")), "1) \"5\"");
+    assert_eq!(h.send_and_get(format!("LPOP test")), "1) \"4\"");
+    assert_eq!(h.send_and_get(format!("LPOP test")), "1) \"3\"");
+    assert_eq!(h.send_and_get(format!("LPOP test")), "1) \"2\"");
+    assert_eq!(h.send_and_get(format!("LPOP test")), "1) \"1\"");
+    assert_eq!(h.send_and_get(format!("LPOP test")), "(nil)");
+
+    // GIVEN 2
+    let res = h.send_and_get(format!("LPUSH test2 1 2 3 4 5"));
+    assert_eq!(res, "(integer) 5");
+
+    //WHEN & ASSERT - 2 at a time
+    assert_eq!(h.send_and_get_vec(format!("LPOP test2 2"), 2), vec!["1) \"5\"", "2) \"4\""]);
+    assert_eq!(h.send_and_get_vec(format!("LPOP test2 2"), 2), vec!["1) \"3\"", "2) \"2\""]);
+
+    Ok(())
+}
+
+#[test]
+fn test_lpop() -> anyhow::Result<()> {
+    for env in [ServerEnv::default(), ServerEnv::default().with_append_only(true)] {
+        run_lpop(env)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description:  Implement LPOP command
This pull request introduces the LPOP command, which removes and returns one or more elements from the head (left side) of a list.

The implementation is integrated throughout the system, from client request parsing to the core cache logic.

## Key Changes:
Command Parsing: The client request parser now recognizes the command. The count argument is optional and defaults to 1 as follows
```
LPOP <key> [count] 
```

Cache Logic:
The CacheActor contains the core `LPOP` logic. It removes the list from the cache, pops the specified number of elements, and places the list back in the cache if it's not empty.

It correctly handles cases where the key does not exist or the list becomes empty, returning a nil or empty array response.

Write Operation: `LPOP` is treated as a write request, ensuring it is logged in the operation log and requires consensus in a clustered environment.



closed #722 