### PR TITLE
refactor: serialize ClientAction in SessionRequest

### DIFF
--- a/duva/src/domains/cluster_actors/command.rs
+++ b/duva/src/domains/cluster_actors/command.rs
@@ -105,7 +105,7 @@ impl From<&'static str> for ConsensusClientResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 pub enum LazyOption {
     Lazy,
     Eager,

--- a/duva/src/domains/operation_logs/operation.rs
+++ b/duva/src/domains/operation_logs/operation.rs
@@ -15,7 +15,7 @@ pub struct WriteOperation {
 /// Client request is converted to WriteOperation and then it turns into WriteOp when it gets offset
 #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 pub enum WriteRequest {
-    Set { key: String, value: String, expires_at: Option<u64> },
+    Set { key: String, value: String, expires_at: Option<i64> },
     MSet { entries: Vec<CacheEntry> },
     Delete { keys: Vec<String> },
     Append { key: String, value: String },

--- a/duva/src/domains/query_io.rs
+++ b/duva/src/domains/query_io.rs
@@ -5,6 +5,7 @@ use crate::domains::operation_logs::WriteOperation;
 use crate::domains::peers::command::{
     ElectionVote, HeartBeat, MigrateBatch, MigrationBatchAck, ReplicationAck, RequestVote,
 };
+use crate::presentation::clients::request::ClientAction;
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
 use std::fmt::Write;
@@ -28,6 +29,7 @@ const MIGRATION_BATCH_ACK_PREFIX: char = 'M';
 
 const ERR_PREFIX: char = '-';
 const NULL_PREFIX: char = '\u{0000}';
+const CLIENT_ACTION_PREFIX: char = '%';
 pub(crate) const SERDE_CONFIG: bincode::config::Configuration = bincode::config::standard();
 
 #[macro_export]
@@ -46,7 +48,7 @@ pub enum QueryIO {
     Array(Vec<QueryIO>),
     SessionRequest {
         request_id: u64,
-        value: Vec<QueryIO>,
+        client_action: ClientAction,
     },
     Err(Bytes),
 
@@ -111,10 +113,11 @@ impl QueryIO {
                 }
                 buffer.freeze()
             },
-            | QueryIO::SessionRequest { request_id, value } => {
-                let mut buffer = BytesMut::with_capacity(32 + 1 + value.len() * 32);
+            | QueryIO::SessionRequest { request_id, client_action: action } => {
+                let value = serialize_with_bincode(CLIENT_ACTION_PREFIX, &action);
+                let mut buffer = BytesMut::with_capacity(32 + 1 + value.len());
                 buffer.extend_from_slice(format!("!{request_id}\r\n").as_bytes());
-                buffer.extend_from_slice(&QueryIO::Array(value).serialize());
+                buffer.extend_from_slice(&value);
                 buffer.freeze()
             },
             | QueryIO::Err(e) => {
@@ -302,23 +305,15 @@ fn parse_session_request(buffer: Bytes) -> Result<(QueryIO, usize)> {
     offset += count_len;
     let request_id = count_bytes.parse()?;
 
-    // ! to advance '$'
-    offset += 1;
+    let (action_byte, len): (ClientAction, usize) = parse_client_action(buffer.slice(offset..))?;
+    Ok((QueryIO::SessionRequest { request_id, client_action: action_byte }, offset + len))
+}
 
-    let (count_bytes, count_len) = read_until_crlf_exclusive(&buffer.slice(offset..))
-        .ok_or(anyhow::anyhow!("Invalid array length"))?;
-    offset += count_len;
-
-    let array_len = count_bytes.parse()?;
-
-    let mut elements = Vec::with_capacity(array_len);
-
-    for _ in 0..array_len {
-        let (element, len) = deserialize(buffer.slice(offset..))?;
-        offset += len;
-        elements.push(element);
-    }
-    Ok((QueryIO::SessionRequest { request_id, value: elements }, offset))
+fn parse_client_action(buffer: Bytes) -> Result<(ClientAction, usize)> {
+    let (action, len): (ClientAction, usize) =
+        bincode::decode_from_slice(&buffer.slice(1..), SERDE_CONFIG)
+            .map_err(|err| anyhow::anyhow!("Failed to decode client action: {:?}", err))?;
+    Ok((action, len + 1))
 }
 
 pub fn parse_custom_type<T>(buffer: Bytes) -> Result<(QueryIO, usize)>
@@ -549,21 +544,21 @@ mod test {
     #[test]
     fn test_deserialize_session_request() {
         // GIVEN
-        let buffer = Bytes::from("!30\r\n*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n");
+        let buffer = Bytes::from("!30\r\n%\x06\x05hello\x05world");
 
         // WHEN
         let (value, len) = deserialize(buffer).unwrap();
 
         // THEN
-        assert_eq!(len, 31);
+        assert_eq!(len, 19);
         assert_eq!(
             value,
             QueryIO::SessionRequest {
                 request_id: 30,
-                value: vec![
-                    QueryIO::BulkString("hello".into()),
-                    QueryIO::BulkString("world".into()),
-                ]
+                client_action: ClientAction::Set {
+                    key: "hello".to_string(),
+                    value: "world".to_string(),
+                }
             }
         );
     }
@@ -572,14 +567,17 @@ mod test {
         // GIVEN
         let request = QueryIO::SessionRequest {
             request_id: 30,
-            value: vec![QueryIO::BulkString("hello".into()), QueryIO::BulkString("world".into())],
+            client_action: ClientAction::Set {
+                key: "hello".to_string(),
+                value: "world".to_string(),
+            },
         };
 
         // WHEN
         let serialized = request.serialize();
 
         // THEN
-        assert_eq!(serialized, Bytes::from("!30\r\n*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n"));
+        assert_eq!(serialized, Bytes::from("!30\r\n%\x06\x05hello\x05world"));
     }
 
     #[test]

--- a/duva/src/domains/saves/endec/decoder.rs
+++ b/duva/src/domains/saves/endec/decoder.rs
@@ -332,7 +332,7 @@ impl BytesDecoder<'_, MetadataReady> {
     pub fn try_extract_expiry_time_in_milliseconds(&mut self) -> Result<StoredDuration> {
         self.remove_identifier();
         let range = 0..=7;
-        let result = u64::from_le_bytes(
+        let result = i64::from_le_bytes(
             extract_range(self, range.clone())
                 .context("Failed to extract expiry time in milliseconds")?,
         );

--- a/duva/src/domains/saves/endec/mod.rs
+++ b/duva/src/domains/saves/endec/mod.rs
@@ -96,7 +96,7 @@ fn extract_range<const N: usize>(encoded: &[u8], range: RangeInclusive<usize>) -
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StoredDuration {
     Seconds(u32),
-    Milliseconds(u64),
+    Milliseconds(i64),
 }
 
 impl StoredDuration {
@@ -106,7 +106,7 @@ impl StoredDuration {
                 DateTime::<Utc>::from_timestamp(*secs as i64, 0).expect("Invalid timestamp")
             },
             | StoredDuration::Milliseconds(millis) => {
-                DateTime::from_timestamp_millis(*millis as i64).expect("Invalid timestamp")
+                DateTime::from_timestamp_millis(*millis).expect("Invalid timestamp")
             },
         }
     }

--- a/duva/src/presentation/clients/controller.rs
+++ b/duva/src/presentation/clients/controller.rs
@@ -10,6 +10,7 @@ use crate::domains::saves::actor::SaveTarget;
 use crate::prelude::PeerIdentifier;
 use crate::presentation::clients::request::ClientAction;
 use crate::presentation::clusters::communication_manager::ClusterCommunicationManager;
+use chrono::DateTime;
 use std::sync::atomic::Ordering;
 
 #[derive(Clone, Debug)]
@@ -33,10 +34,11 @@ impl ClientController {
                     .await?
                     .into(),
             ),
-            | ClientAction::SetWithExpiry { key, value, expiry } => QueryIO::SimpleString(
+            | ClientAction::SetWithExpiry { key, value, expires_at } => QueryIO::SimpleString(
                 self.cache_manager
                     .route_set(
-                        CacheEntry::new(key, value.as_str()).with_expiry(expiry),
+                        CacheEntry::new(key, value.as_str())
+                            .with_expiry(DateTime::from_timestamp_millis(expires_at).unwrap()),
                         current_index.unwrap(),
                     )
                     .await?

--- a/duva/src/presentation/clients/request.rs
+++ b/duva/src/presentation/clients/request.rs
@@ -7,7 +7,7 @@ use crate::domains::{
     peers::identifier::{PeerIdentifier, TPeerAddress},
 };
 use anyhow::Context;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 
 #[derive(Clone, Debug)]
 pub enum ClientAction {
@@ -19,7 +19,7 @@ pub enum ClientAction {
     IndexGet { key: String, index: u64 },
     Set { key: String, value: String },
     Append { key: String, value: String },
-    SetWithExpiry { key: String, value: String, expiry: DateTime<Utc> },
+    SetWithExpiry { key: String, value: String, expires_at: i64 },
     Keys { pattern: Option<String> },
     Delete { keys: Vec<String> },
     Save,
@@ -56,13 +56,10 @@ impl ClientAction {
             | ClientAction::Set { key, value } => {
                 WriteRequest::Set { key: key.clone(), value: value.clone(), expires_at: None }
             },
-            | ClientAction::SetWithExpiry { key, value, expiry } => {
-                let expires_at = expiry.timestamp_millis() as u64;
-                WriteRequest::Set {
-                    key: key.clone(),
-                    value: value.clone(),
-                    expires_at: Some(expires_at),
-                }
+            | ClientAction::SetWithExpiry { key, value, expires_at } => WriteRequest::Set {
+                key: key.clone(),
+                value: value.clone(),
+                expires_at: Some(*expires_at),
             },
             | ClientAction::Append { key, value } => {
                 WriteRequest::Append { key: key.clone(), value: value.clone() }
@@ -149,7 +146,7 @@ pub fn extract_action(action: &str, args: &[&str]) -> anyhow::Result<ClientActio
             Ok(ClientAction::SetWithExpiry {
                 key: args[0].to_string(),
                 value: args[1].to_string(),
-                expiry: extract_expiry(args[3])?,
+                expires_at: extract_expiry(args[3])?,
             })
         },
 
@@ -374,30 +371,13 @@ pub fn extract_action(action: &str, args: &[&str]) -> anyhow::Result<ClientActio
     }
 }
 
-pub fn extract_expiry(expiry: &str) -> anyhow::Result<DateTime<Utc>> {
+pub fn extract_expiry(expiry: &str) -> anyhow::Result<i64> {
     let expiry = expiry.parse::<i64>().context("Invalid expiry")?;
-    Ok(Utc::now() + chrono::Duration::milliseconds(expiry))
+    Ok((Utc::now() + chrono::Duration::milliseconds(expiry)).timestamp_millis())
 }
 
 #[derive(Clone, Debug)]
 pub struct ClientRequest {
     pub(crate) action: ClientAction,
     pub(crate) session_req: SessionRequest,
-}
-
-impl ClientRequest {
-    pub fn from_user_input(
-        value: Vec<QueryIO>,
-        session_req: SessionRequest,
-    ) -> anyhow::Result<Self> {
-        let mut values = value.into_iter().flat_map(|v| v.unpack_single_entry::<String>());
-        let command = values.next().ok_or(anyhow::anyhow!("Unexpected command format"))?;
-        let (command, args) = (command, values.collect::<Vec<_>>());
-
-        let cli_action =
-            extract_action(&command, &args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-                .map_err(|e| anyhow::anyhow!(e))?;
-
-        Ok(ClientRequest { action: cli_action, session_req })
-    }
 }

--- a/duva/src/presentation/clients/request.rs
+++ b/duva/src/presentation/clients/request.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use crate::domains::{
-    QueryIO,
     cluster_actors::{LazyOption, SessionRequest},
     operation_logs::WriteRequest,
     peers::identifier::{PeerIdentifier, TPeerAddress},
@@ -9,7 +8,7 @@ use crate::domains::{
 use anyhow::Context;
 use chrono::Utc;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 pub enum ClientAction {
     Ping,
     Echo(String),

--- a/duva/src/presentation/clients/stream.rs
+++ b/duva/src/presentation/clients/stream.rs
@@ -72,13 +72,12 @@ impl ClientStreamReader {
         query_ios
             .into_iter()
             .map(|query_io| {
-                let QueryIO::SessionRequest { request_id, value } = query_io else {
+                let QueryIO::SessionRequest { request_id, client_action } = query_io else {
                     return Err(IoError::Custom("Unexpected command format".to_string()));
                 };
                 let session_request = SessionRequest::new(request_id, self.client_id);
 
-                ClientRequest::from_user_input(value, session_request)
-                    .map_err(|e| IoError::Custom(e.to_string()))
+                Ok(ClientRequest { action: client_action, session_req: session_request })
             })
             .collect()
     }

--- a/duva/tests/common.rs
+++ b/duva/tests/common.rs
@@ -258,14 +258,6 @@ pub fn array(arr: Vec<&str>) -> Bytes {
         .serialize()
 }
 
-pub fn session_request(request_id: u64, arr: Vec<&str>) -> Bytes {
-    QueryIO::SessionRequest {
-        request_id,
-        value: arr.iter().map(|s| QueryIO::BulkString(s.to_string().into())).collect(),
-    }
-    .serialize()
-}
-
 pub struct Client {
     pub child: Child,
     reader: Option<BufReader<ChildStdout>>,


### PR DESCRIPTION
- unify milliseconds type to i64 from u64: in the code, every place converting u64 to DateTime, we did the i64 type conversion, which is unnecessary.
- now ClientAction have `expires_at` (timestamp in milliseconds). Previously, it was DateTime<Utc>: If we had DateTime<Utc>, cannot convert to bincode
- Serialize ClientAction with bincode inside SessionRequest so that Server doesn’t need to parse user input directly

Resolves: #755 