### PR TITLE
feat: event trigger on peer discovery

### DIFF
--- a/duva/src/domains/cluster_actors/command.rs
+++ b/duva/src/domains/cluster_actors/command.rs
@@ -30,6 +30,7 @@ pub enum SchedulerMessage {
     TryUnblockWriteReqs,
     SendBatchAck { batch_id: BatchId, to: PeerIdentifier },
 }
+
 impl From<SchedulerMessage> for ClusterCommand {
     fn from(msg: SchedulerMessage) -> Self {
         ClusterCommand::Scheduler(msg)

--- a/duva/src/domains/cluster_actors/command.rs
+++ b/duva/src/domains/cluster_actors/command.rs
@@ -10,6 +10,7 @@ use crate::types::{Callback, ConnectionStream};
 
 use std::str::FromStr;
 
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -43,6 +44,8 @@ pub enum ConnectionMessage {
     AcceptInboundPeer { stream: ConnectionStream },
     AddPeer(Peer, Option<Callback<anyhow::Result<()>>>),
     FollowerSetReplId(ReplicationId, PeerIdentifier),
+    ActivateClusterSync(Callback<()>),
+    RequestClusterSyncAwaiter(Callback<Option<oneshot::Receiver<()>>>),
 }
 impl From<ConnectionMessage> for ClusterCommand {
     fn from(msg: ConnectionMessage) -> Self {

--- a/duva/src/domains/cluster_actors/service.rs
+++ b/duva/src/domains/cluster_actors/service.rs
@@ -156,9 +156,10 @@ impl<T: TWriteAheadLog> ClusterActor<T> {
                 self.connect_to_server(connect_to, Some(callback)).await
             },
             | AcceptInboundPeer { stream } => self.accept_inbound_stream(stream),
-
             | AddPeer(peer, optional_callback) => self.add_peer(peer, optional_callback).await,
             | FollowerSetReplId(replication_id, _leader_id) => self.follower_setup(replication_id),
+            | ActivateClusterSync(callback) => self.activate_cluster_sync(callback),
+            | RequestClusterSyncAwaiter(callback) => self.send_cluster_sync_awaiter(callback),
         }
     }
 }


### PR DESCRIPTION
## Challange
When eager rebalancing is requested, there is a chance that non-coordinating node is not yet aware of joining node and migration fails as it hasn't established connections. 

We figured that this is general problem for "event on cluster join" 

## Solution
Considering how actor guarantees the message consumption order while providing asynchrony, 
I had to figure out background task that start working upon certain kind of callback chain. 

### The first callback : When connection to seed node is estabilished
Connection establishment requires handshakes and if it is not done in the background, actor will just hang due to synchronous back-and-forth communication where one is waiting for the other to send the next message while the other is doing the same - canonical example of deadlock

### The second callback
Upon completion on connection, we also need to conditionally activate cluster sync - which requires communication with actor itself. Here, we "activate" cluster synchronization for the final callback

### The final callback
This callback waits for the synchronization is done. Upon completion, it starts what's supposed to do. In this case, triggering rebalancing. 



## Related issue
closed #768
