### PR TITLE
feat: o(1) rpop for quick list

### DIFF
--- a/duva/src/domains/cluster_actors/actor/tests/replications.rs
+++ b/duva/src/domains/cluster_actors/actor/tests/replications.rs
@@ -58,7 +58,6 @@ async fn test_generate_follower_entries() {
     ];
 
     cluster_actor.replication.logger.con_idx.store(3, Ordering::Release);
-
     cluster_actor.replication.logger.follower_write_entries(test_logs).unwrap();
 
     //WHEN


### PR DESCRIPTION
- Achieved a constant-time O(1) RPOP operation by adding a tail offset to the ziplist.
- Implemented lazy compression, which now runs after LPUSH and RPUSH operations when new nodes are added.