### PR TITLE
chore: add bias to election timer

### DIFF
--- a/duva/src/domains/cluster_actors/actor/heartbeat_scheduler.rs
+++ b/duva/src/domains/cluster_actors/actor/heartbeat_scheduler.rs
@@ -261,7 +261,8 @@ mod tests {
 
         // Test election trigger after timeout
         let (tx2, mut rx2) = ClusterActorQueue::new(10);
-        let _ = HeartBeatScheduler::start_election_timer(tx2);
+        // ! Keep the sender alive! otherwise, the receiver will close immediately
+        let _sender = HeartBeatScheduler::start_election_timer(tx2);
 
         let election_triggered =
             timeout(Duration::from_millis(HEARTBEAT_INTERVAL * 6), async { rx2.recv().await })


### PR DESCRIPTION
By default, tokio's `select!` is fair. 

In rare case, this can lead to landing on timeout branch even though a stop was already waiting in the channel. 

